### PR TITLE
Updating SDK and Improving Inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ This changelog documents the changes between release versions.
 
 Changes to be included in the next upcoming releaase.
 
+## v0.10
+
+PR: https://github.com/hasura/ndc-typescript-deno/pull/57
+
+* Types names are now preserved when possible
+* Depends on the latest version of the TS SDK which no longer needs multiregion functions
+* Defines arraybuffer and blob scalars
+* Sets MAX_INFERENCE_RECURSION = 20 to break any potential infinite recursion loops
+* New tests have been created for refactored inference cases
+
+## v0.9
+
+Full-Stack Typescript!
+
 * Ported main server from Rust to pure Deno
 * Support exposing optional function parameters
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Limitations:
 * Optional object fields are not currently supported
 * Complex input types are supported by the connector, but are not supported in "commands" in Hasura3 projects
 * Functions can be executed via both the `/query` and `/mutation` endpoints
+* Conflicting type names in dependencies will be namespaced with their relative path
+* Generic type parameters will be treated as scalars when referenced
 
 Please [file an issue](https://github.com/hasura/ndc-typescript-deno/issues/new) for any problems you encounter during usage of this connector.
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ and others as procedures, which will become queries and mutations respectively.
 
 Limitations:
 
-* The `deno vendor` step must be run by hand for local development
+* ~~The `deno vendor` step must be run by hand for local development~~ (vendoring is now automatic by default)
 * Functions can be sync, or async, but `Promise`'s can't be nested
 * All numbers are exported as `Float`s
 * Unrecognised types will become opaque scalars, for example: union types.

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -1,6 +1,6 @@
 
 import { FunctionPositions, ProgramInfo, programInfo, Struct } from "./infer.ts";
-import { resolve } from 'https://deno.land/std@0.201.0/path/resolve.ts';
+import { resolve } from "https://deno.land/std@0.203.0/path/mod.ts";
 import { JSONSchemaObject } from "npm:@json-schema-tools/meta-schema";
 
 import * as sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.3';

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -190,8 +190,8 @@ function validate_type(root_file: string, checker: ts.TypeChecker, object_names:
     error('validate_type failed');
   }
 
-  // TODO: We should resolve generic type parameters somewhere
-  // See: https://github.com/hasura/ndc-typescript-deno/issues/58
+  // TODO: https://github.com/hasura/ndc-typescript-deno/issues/58 We should resolve generic type parameters somewhere
+  //
   // else if (ty.constraint) {
   //   return validate_type(root_file, checker, object_names, schema_response, name, ty.constraint, depth + 1)
   // }

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -9,7 +9,7 @@
  */
 
 import ts, { FunctionDeclaration } from "npm:typescript@5.1.6";
-import { resolve, dirname } from "https://deno.land/std@0.201.0/path/posix.ts";
+import { resolve, dirname } from "https://deno.land/std@0.203.0/path/mod.ts";
 import {existsSync} from "https://deno.land/std@0.201.0/fs/mod.ts";
 import { FunctionInfo, ScalarType, SchemaResponse, Type } from 'npm:@hasura/ndc-sdk-typescript@1.0.0';
 

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -9,7 +9,7 @@
  */
 
 import ts, { FunctionDeclaration } from "npm:typescript@5.1.6";
-import { resolve } from "https://deno.land/std@0.201.0/path/posix.ts";
+import { resolve, dirname } from "https://deno.land/std@0.201.0/path/posix.ts";
 import {existsSync} from "https://deno.land/std@0.201.0/fs/mod.ts";
 import { FunctionInfo, ScalarType, SchemaResponse, Type } from 'npm:@hasura/ndc-sdk-typescript@1.0.0';
 
@@ -46,6 +46,9 @@ const scalar_mappings: {[key: string]: string} = {
   "bool": "Boolean",
   "boolean": "Boolean",
   "number": "Float",
+  "arraybuffer": "ArrayBuffer", // Treat ArrayBuffer as scalar since it shouldn't recur
+  "blob": "Blob",               // Treat ArrayBuffer as scalar since it shouldn't recur
+  // "void": "Void",            // Void type can be included to permit void types as scalars
 };
 
 // NOTE: This should be able to be made read only
@@ -58,18 +61,92 @@ const no_ops: ScalarType = {
 // TODO: https://github.com/hasura/ndc-typescript-deno/issues/21 Use standard logging from SDK
 const LOG_LEVEL = Deno.env.get("LOG_LEVEL") || "INFO";
 const DEBUG = LOG_LEVEL == 'DEBUG';
+const MAX_INFERENCE_RECURSION = 20; // Better to abort than get into an infinite loop, this could be increased if required.
 
-function validate_type(checker: ts.TypeChecker, schema_response: SchemaResponse, name: string, ty: any): Type {
+type TYPE_NAMES = Array<{
+  type: ts.Type,
+  name: string
+}>;
+
+function gql_name(n: string): string {
+  // Construct a GraphQL complient name: https://spec.graphql.org/draft/#sec-Type-Name-Introspection
+  // Check if this is actually required.
+  return n.replace(/^[^a-zA-Z]/, '').replace(/[^0-9a-zA-Z]/g,'_');
+}
+
+function qualified_type_name(root_file: string, checker: ts.TypeChecker, t: any, names: TYPE_NAMES): string {
+  const symbol = t.getSymbol()!;
+  const type_str = checker.typeToString(t);
+
+  if(! symbol) {
+    throw new Error(`Couldn't find symbol for type ${type_str}`);
+  }
+
+  const locations = symbol.declarations.map((d: any) => d.getSourceFile());
+  for(const f of locations) {
+    const where = f.fileName;
+    const short = where.replace(dirname(root_file) + '/','').replace(/\.ts$/, '');
+
+    // If the type is present in the entrypoint, don't qualify the name
+    // If it is under the entrypoint's directory qualify with the subpath
+    // Otherwise, use the minimum ancestor of the type's location to ensure non-conflict
+    if(root_file == where) {
+      return type_str;
+    } else if (short.length < where.length) {
+      return `${gql_name(short)}_${type_str}`;
+    } else {
+      const split = where.split('/');
+      const len = split.length;
+      for(let i = len - 2; i > 0; i--) {
+        const joined = split.slice(i, len).join('/');
+        const name = `${gql_name(joined)}_${type_str}`;
+        if(! find_type_name(names,name)) {
+          return name;
+        }
+      }
+      throw new Error(`Couldn't find any declarations for type ${type_str}`);
+    }
+  }
+
+  throw new Error(`Couldn't find any declarations for type ${type_str}`);
+}
+
+function find_type_name(names: TYPE_NAMES, name: string): string | undefined {
+  for(const p of names) {
+    if(name == p.name) {
+      return p.name;
+    }
+  }
+  return;
+};
+
+function lookup_type_name(root_file: string, checker: ts.TypeChecker, names: TYPE_NAMES, t: ts.Type): string {
+  for(const p of names) {
+    if(t == p.type) {
+      return p.name;
+    }
+  }
+  const new_name = qualified_type_name(root_file, checker, t, names);
+  names.push({type: t, name: new_name});
+  return new_name;
+};
+
+function validate_type(root_file: string, checker: ts.TypeChecker, OBJECT_NAMES: TYPE_NAMES, schema_response: SchemaResponse, name: string, ty: any, depth: number): Type {
   const type_str = checker.typeToString(ty);
   const type_name = ty.symbol?.escapedName || ty.intrinsicName || 'unknown_type';
   const type_name_lower: string = type_name.toLowerCase();
+
+  if(depth > MAX_INFERENCE_RECURSION) {
+    error(`Schema inference validation exceeded depth ${MAX_INFERENCE_RECURSION} for type ${type_str}`);
+  }
+  console.error(`validate type ${name}: ${type_name} ~ ${type_str}`);
 
   // PROMISE
   // TODO: https://github.com/hasura/ndc-typescript-deno/issues/32 There is no recursion that resolves inner promises.
   //       Nested promises should be resolved in the function definition.
   if (type_name == "Promise") {
     const inner_type = ty.resolvedTypeArguments[0];
-    const inner_type_result = validate_type(checker, schema_response, name, inner_type);
+    const inner_type_result = validate_type(root_file, checker, OBJECT_NAMES, schema_response, name, inner_type, depth + 1);
     return inner_type_result;
   }
 
@@ -77,7 +154,7 @@ function validate_type(checker: ts.TypeChecker, schema_response: SchemaResponse,
   // TODO: https://github.com/hasura/ndc-typescript-deno/issues/33 There should be a library function that allows us to check this case
   else if (type_name == "Array") {
     const inner_type = ty.resolvedTypeArguments[0];
-    const inner_type_result = validate_type(checker, schema_response, name, inner_type);
+    const inner_type_result = validate_type(root_file, checker, OBJECT_NAMES, schema_response, `Array_of_${name}`, inner_type, depth + 1);
     return { type: 'array', element_type: inner_type_result };
   }
 
@@ -91,24 +168,39 @@ function validate_type(checker: ts.TypeChecker, schema_response: SchemaResponse,
   // OBJECT
   // TODO: https://github.com/hasura/ndc-typescript-deno/issues/33 There should be a library function that allows us to check this case
   else if (is_struct(ty)) {
+    const type_str_qualified = lookup_type_name(root_file, checker, OBJECT_NAMES, ty);
+    
+    // Shortcut recursion if the type has already been named
+    if(schema_response.object_types[type_str_qualified]) {
+      return { type: 'named', name: type_str_qualified };
+    }
+
+    schema_response.object_types[type_str] = Object(); // Break infinite recursion
     const fields = Object.fromEntries(Array.from(ty.members, ([k, v]) => {
+      console.error(name);
+      // console.error(checker.getTypeAtLocation(v.declarations[0]));
       const field_type = checker.getTypeAtLocation(v.declarations[0].type);
-      const field_type_validated = validate_type(checker, schema_response, `${name}_field_${k}`, field_type);
+      const field_type_validated = validate_type(root_file, checker, OBJECT_NAMES, schema_response, `${name}_field_${k}`, field_type, depth + 1);
       return [k, { type: field_type_validated }];
     }));
 
-    schema_response.object_types[name] = { fields };
-    return { type: 'named', name: name}
+    schema_response.object_types[type_str_qualified] = { fields };
+    return { type: 'named', name: type_str_qualified}
   }
 
   else if (type_name == "void") {
-    console.error(`void functions are not supported`);
+    console.error(`void functions are not supported: ${name}`);
     error('validate_type failed');
   }
+
+  // else if (ty.constraint) {
+  //   return validate_type(root_file, checker, OBJECT_NAMES, schema_response, name, ty.constraint, depth + 1)
+  // }
 
   // UNHANDLED: Assume that the type is a scalar
   else {
     console.error(`Unable to validate type of ${name}: ${type_str} (${type_name}). Assuming that it is a scalar type.`);
+    console.error(ty.typeArguments);
     schema_response.scalar_types[name] = no_ops;
     return { type: 'named', name };
   }
@@ -254,6 +346,8 @@ export function programInfoException(filename_arg?: string, vendor_arg?: string,
     procedures: [],
   };
 
+  const OBJECT_NAMES = [] as TYPE_NAMES;
+
   const positions: FunctionPositions = {};
 
   function isExported(node: FunctionDeclaration): boolean {
@@ -280,6 +374,8 @@ export function programInfoException(filename_arg?: string, vendor_arg?: string,
       continue;
     }
 
+    const root_file = resolve(filename);
+
     ts.forEachChild(src, (node) => {
       if (ts.isFunctionDeclaration(node)) {
         const fn_sym = checker.getSymbolAtLocation(node.name!)!;
@@ -298,7 +394,9 @@ export function programInfoException(filename_arg?: string, vendor_arg?: string,
         const call = fn_type.getCallSignatures()[0]!;
         const result_type = call.getReturnType();
         const result_type_name = `${fn_name}_output`;
-        const result_type_validated = validate_type(checker, schema_response, result_type_name, result_type);
+
+        // console.error((result_type as any).symbol.typeArguments);
+        const result_type_validated = validate_type(root_file, checker, OBJECT_NAMES, schema_response, result_type_name, result_type, 0);
         const description = fn_desc ? { description: fn_desc } : {}
 
         const fn: FunctionInfo = {
@@ -316,7 +414,7 @@ export function programInfoException(filename_arg?: string, vendor_arg?: string,
           const param_type = checker.getTypeOfSymbolAtLocation(param, param.valueDeclaration!);
           // TODO: https://github.com/hasura/ndc-typescript-deno/issues/34 Use the user's given type name if one exists.
           const type_name = `${fn_name}_arguments_${param_name}`;
-          const param_type_validated = validate_type(checker, schema_response, type_name, param_type); // E.g. `bio_arguments_username`
+          const param_type_validated = validate_type(root_file, checker, OBJECT_NAMES, schema_response, type_name, param_type, 0); // E.g. `bio_arguments_username`
           const description = param_desc ? { description: param_desc } : {}
 
           positions[fn.name].push(param_name);

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -97,7 +97,7 @@ function qualified_type_name(root_file: string, checker: ts.TypeChecker, t: any,
     } else {
       const split = where.split('/');
       const len = split.length;
-      for(let i = len - 2; i > 0; i--) {
+      for(let i = len - 2; i >= 0; i--) {
         const joined = split.slice(i, len).join('/');
         const name = `${gql_name(joined)}_${type_str}`;
         if(! find_type_name(names,name)) {

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -63,7 +63,7 @@ const LOG_LEVEL = Deno.env.get("LOG_LEVEL") || "INFO";
 const DEBUG = LOG_LEVEL == 'DEBUG';
 const MAX_INFERENCE_RECURSION = 20; // Better to abort than get into an infinite loop, this could be increased if required.
 
-type TYPE_NAMES = Array<{
+type TypeNames = Array<{
   type: ts.Type,
   name: string
 }>;
@@ -74,7 +74,7 @@ function gql_name(n: string): string {
   return n.replace(/^[^a-zA-Z]/, '').replace(/[^0-9a-zA-Z]/g,'_');
 }
 
-function qualified_type_name(root_file: string, checker: ts.TypeChecker, t: any, names: TYPE_NAMES): string {
+function qualified_type_name(root_file: string, checker: ts.TypeChecker, t: any, names: TypeNames): string {
   const symbol = t.getSymbol()!;
   const type_str = checker.typeToString(t);
 
@@ -111,7 +111,7 @@ function qualified_type_name(root_file: string, checker: ts.TypeChecker, t: any,
   throw new Error(`Couldn't find any declarations for type ${type_str}`);
 }
 
-function find_type_name(names: TYPE_NAMES, name: string): string | undefined {
+function find_type_name(names: TypeNames, name: string): string | undefined {
   for(const p of names) {
     if(name == p.name) {
       return p.name;
@@ -120,7 +120,7 @@ function find_type_name(names: TYPE_NAMES, name: string): string | undefined {
   return;
 };
 
-function lookup_type_name(root_file: string, checker: ts.TypeChecker, names: TYPE_NAMES, t: ts.Type): string {
+function lookup_type_name(root_file: string, checker: ts.TypeChecker, names: TypeNames, t: ts.Type): string {
   for(const p of names) {
     if(t == p.type) {
       return p.name;
@@ -131,7 +131,7 @@ function lookup_type_name(root_file: string, checker: ts.TypeChecker, names: TYP
   return new_name;
 };
 
-function validate_type(root_file: string, checker: ts.TypeChecker, OBJECT_NAMES: TYPE_NAMES, schema_response: SchemaResponse, name: string, ty: any, depth: number): Type {
+function validate_type(root_file: string, checker: ts.TypeChecker, OBJECT_NAMES: TypeNames, schema_response: SchemaResponse, name: string, ty: any, depth: number): Type {
   const type_str = checker.typeToString(ty);
   const type_name = ty.symbol?.escapedName || ty.intrinsicName || 'unknown_type';
   const type_name_lower: string = type_name.toLowerCase();
@@ -344,7 +344,7 @@ export function programInfoException(filename_arg?: string, vendor_arg?: string,
     procedures: [],
   };
 
-  const OBJECT_NAMES = [] as TYPE_NAMES;
+  const OBJECT_NAMES = [] as TypeNames;
 
   const positions: FunctionPositions = {};
 

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -191,6 +191,7 @@ function validate_type(root_file: string, checker: ts.TypeChecker, OBJECT_NAMES:
   }
 
   // TODO: We should resolve generic type parameters somewhere
+  // See: https://github.com/hasura/ndc-typescript-deno/issues/58
   // else if (ty.constraint) {
   //   return validate_type(root_file, checker, OBJECT_NAMES, schema_response, name, ty.constraint, depth + 1)
   // }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -5,11 +5,10 @@
  */
 
 // NOTE: Ensure that sdk matches version in connector.ts
-import * as sdk        from 'npm:@hasura/ndc-sdk-typescript@1.1.0';
 import * as commander  from 'npm:commander@11.0.0';
 import * as path       from "https://deno.land/std@0.203.0/path/mod.ts";
 import { programInfo } from './infer.ts'
-import { connector   } from './connector.ts'
+import { connector, sdk } from './connector.ts'
 
 const inferCommand = new commander.Command("infer")
   .argument('<path>', 'Typescript source entrypoint')

--- a/src/test/conflicting_names_test.ts
+++ b/src/test/conflicting_names_test.ts
@@ -1,0 +1,82 @@
+
+import * as test  from "https://deno.land/std@0.202.0/assert/mod.ts";
+import * as path  from "https://deno.land/std@0.203.0/path/mod.ts";
+import * as infer from '../infer.ts';
+
+Deno.test("Conflicting Type Names in Imports", () => {
+  const program_path = path.fromFileUrl(import.meta.resolve('./data/conflicting_names.ts'));
+  const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
+
+  const program_results = infer.programInfo(program_path, vendor_path, false);
+
+  test.assertEquals(program_results, {
+    positions: {
+      foo: [],
+    },
+    schema: {
+      collections: [],
+      functions: [],
+      object_types: {
+        Foo: {
+          fields: {
+            x: {
+              type: {
+                name: "Boolean",
+                type: "named",
+              },
+            },
+            y: {
+              type: {
+                name: "conflicting_names_dep_Foo",
+                type: "named",
+              },
+            },
+          },
+        },
+        conflicting_names_dep_Foo: {
+          fields: {
+            a: {
+              type: {
+                name: "String",
+                type: "named",
+              },
+            },
+            b: {
+              type: {
+                name: "Float",
+                type: "named",
+              },
+            },
+          },
+        },
+      },
+      procedures: [
+        {
+          arguments: {},
+          name: "foo",
+          result_type: {
+            name: "Foo",
+            type: "named",
+          },
+        },
+      ],
+      scalar_types: {
+        Boolean: {
+          aggregate_functions: {},
+          comparison_operators: {},
+          update_operators: {},
+        },
+        Float: {
+          aggregate_functions: {},
+          comparison_operators: {},
+          update_operators: {},
+        },
+        String: {
+          aggregate_functions: {},
+          comparison_operators: {},
+          update_operators: {},
+        },
+      }
+    }
+  })
+});

--- a/src/test/data/conflicting_names.ts
+++ b/src/test/data/conflicting_names.ts
@@ -1,0 +1,17 @@
+
+import * as dep from './conflicting_names_dep.ts';
+
+type Foo = {
+  x: boolean,
+  y: dep.Foo
+}
+
+export function foo(): Foo {
+  return {
+    x: true,
+    y: {
+      a: 'hello',
+      b: 33
+    }
+  }
+}

--- a/src/test/data/conflicting_names_dep.ts
+++ b/src/test/data/conflicting_names_dep.ts
@@ -1,0 +1,5 @@
+
+export type Foo = {
+  a: string,
+  b: number
+}

--- a/src/test/data/recursive.ts
+++ b/src/test/data/recursive.ts
@@ -1,0 +1,18 @@
+
+
+// Named types should prevent infinite recursion in schema inference
+
+type Foo = {
+  a: number,
+  b: Array<Foo>
+}
+
+export function bar(): Foo {
+  return {
+      a: 1,
+      b: [{
+        a: 2,
+        b: []
+      }]
+  }
+}

--- a/src/test/data/type_parameters.ts
+++ b/src/test/data/type_parameters.ts
@@ -1,0 +1,24 @@
+
+
+// This tests that type parameters for object don't short circuit with a scalar
+
+type Foo = {
+  a: number,
+  b: string
+}
+
+type Bar<X> = {
+  x: number,
+  y: X
+}
+
+// Foo and Bar should both have `object_types` defined.
+export function bar(): Bar<Foo> {
+  return {
+    x: 1,
+    y: {
+      a: 2,
+      b: 'hello'
+    }
+  }
+}

--- a/src/test/infer_test.ts
+++ b/src/test/infer_test.ts
@@ -84,7 +84,7 @@ Deno.test("Complex Inference", () => {
       collections: [],
       functions: [],
       object_types: {
-        complex_output: {
+        Result: {
           fields: {
             bod: {
               type: {
@@ -134,7 +134,7 @@ Deno.test("Complex Inference", () => {
           },
           name: "complex",
           result_type: {
-            name: "complex_output",
+            name: "Result",
             type: "named",
           },
         },

--- a/src/test/recursive_types_test.ts
+++ b/src/test/recursive_types_test.ts
@@ -1,0 +1,59 @@
+
+import * as test  from "https://deno.land/std@0.202.0/assert/mod.ts";
+import * as path  from "https://deno.land/std@0.203.0/path/mod.ts";
+import * as infer from '../infer.ts';
+
+Deno.test("Recursive Types", () => {
+  const program_path = path.fromFileUrl(import.meta.resolve('./data/recursive.ts'));
+  const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
+
+  const program_results = infer.programInfo(program_path, vendor_path, false);
+
+  test.assertEquals(program_results, {
+    positions: {
+      bar: [],
+    },
+    schema: {
+      collections: [],
+      functions: [],
+      object_types: {
+        Foo: {
+          fields: {
+            a: {
+              type: {
+                name: "Float",
+                type: "named",
+              },
+            },
+            b: {
+              type: {
+                element_type: {
+                  name: "Foo",
+                  type: "named",
+                },
+                type: "array",
+              },
+            },
+          },
+        },
+      },
+      procedures: [
+        {
+          arguments: {},
+          name: "bar",
+          result_type: {
+            name: "Foo",
+            type: "named",
+          },
+        },
+      ],
+      scalar_types: {
+        Float: {
+          aggregate_functions: {},
+          comparison_operators: {},
+          update_operators: {},
+        },
+      },
+    }
+  });
+});

--- a/src/test/type_parameters_test.ts
+++ b/src/test/type_parameters_test.ts
@@ -1,6 +1,6 @@
 
 import * as test    from "https://deno.land/std@0.202.0/assert/mod.ts";
-import * as path    from "https://deno.land/std/path/mod.ts";
+import * as path    from "https://deno.land/std@0.203.0/path/mod.ts";
 import * as infer   from '../infer.ts';
 
 Deno.test({ name: "Type Parameters",

--- a/src/test/type_parameters_test.ts
+++ b/src/test/type_parameters_test.ts
@@ -3,13 +3,15 @@ import * as test    from "https://deno.land/std@0.202.0/assert/mod.ts";
 import * as path    from "https://deno.land/std/path/mod.ts";
 import * as infer   from '../infer.ts';
 
-Deno.test("Type Parameters", () => {
+Deno.test({ name: "Type Parameters",
+ ignore: true,
+ fn() {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/type_parameters.ts'));
   const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
 
   const program_results = infer.programInfo(program_path, vendor_path, false);
 
-  // TODO: Currently broken since validation short-circuits as a scalar on nested parameter field.
+  // TODO: Currently broken since parameters aren't normalised
 
   test.assertEquals(program_results, {
     positions: {
@@ -77,4 +79,4 @@ Deno.test("Type Parameters", () => {
     }
   });
 
-});
+}});

--- a/src/test/type_parameters_test.ts
+++ b/src/test/type_parameters_test.ts
@@ -1,0 +1,80 @@
+
+import * as test    from "https://deno.land/std@0.202.0/assert/mod.ts";
+import * as path    from "https://deno.land/std/path/mod.ts";
+import * as infer   from '../infer.ts';
+
+Deno.test("Type Parameters", () => {
+  const program_path = path.fromFileUrl(import.meta.resolve('./data/type_parameters.ts'));
+  const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
+
+  const program_results = infer.programInfo(program_path, vendor_path, false);
+
+  // TODO: Currently broken since validation short-circuits as a scalar on nested parameter field.
+
+  test.assertEquals(program_results, {
+    positions: {
+      bar: [],
+    },
+    schema: {
+      collections: [],
+      functions: [],
+      object_types: {
+        "Bar<Foo>": {
+          fields: {
+            x: {
+              type: {
+                name: "Float",
+                type: "named",
+              },
+            },
+            y: {
+              type: {
+                name: "bar_output_field_y",
+                type: "named",
+              },
+            },
+          },
+        },
+        "Foo": {
+          fields: {
+            a: {
+              type: {
+                name: "Float",
+                type: "named",
+              },
+            },
+            b: {
+              type: {
+                name: "Float",
+                type: "named",
+              },
+            },
+          },
+        },
+      },
+      scalar_types: {
+        Float: {
+          aggregate_functions: {},
+          comparison_operators: {},
+          update_operators: {},
+        },
+        String: {
+          aggregate_functions: {},
+          comparison_operators: {},
+          update_operators: {},
+        },
+      },
+      procedures: [
+        {
+          arguments: {},
+          name: "bar",
+          result_type: {
+            name: "Bar<Foo>",
+            type: "named",
+          },
+        },
+      ],
+    }
+  });
+
+});

--- a/src/test/void_test.ts
+++ b/src/test/void_test.ts
@@ -6,7 +6,7 @@ import * as infer   from '../infer.ts';
 // NOTE: It would be good to have explicit timeout for this
 // See: https://github.com/denoland/deno/issues/11133
 // Test bug: https://github.com/hasura/ndc-typescript-deno/issues/45
-Deno.test("Infinite Loop", () => {
+Deno.test("Void Types", () => {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/infinite_loop.ts'));
   const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
 

--- a/src/test/void_test.ts
+++ b/src/test/void_test.ts
@@ -1,6 +1,6 @@
 
 import * as test    from "https://deno.land/std@0.202.0/assert/mod.ts";
-import * as path    from "https://deno.land/std/path/mod.ts";
+import * as path    from "https://deno.land/std@0.203.0/path/mod.ts";
 import * as infer   from '../infer.ts';
 
 // NOTE: It would be good to have explicit timeout for this


### PR DESCRIPTION
Fixes: https://github.com/hasura/ndc-typescript-deno/issues/34
Fixes: https://github.com/hasura/ndc-typescript-deno/issues/30


This PR updates the TS Deno connector with the following changes:

* Depends on the latest version of the TS SDK which no longer needs multiregion functions
* Update path dep: https://deno.land/std@0.203.0/path/mod.ts
* Defines `arraybuffer` and `blob` scalars
* Sets `MAX_INFERENCE_RECURSION = 20` to break any potential infinite recursion loops
* Types names are now preserved when possible
* Types referenced from dependencies will be qualified by their path
* Tests have been created in the `test/` directory for the refactored inference cases
    * conflicting_names_test.ts
    * recursive_types_test.ts
    * type_parameters_test.ts - ignored (https://github.com/hasura/ndc-typescript-deno/issues/58)
* Other existing tests have been updated to use the new improved type names

Generic type parameters are still not handled correctly, for example, the following will infer `Bar.y` as a scalar.

```typescript
type Foo = {
  a: number,
  b: string
}

type Bar<X> = {
  x: number,
  y: X
}

export function bar(): Bar<Foo> {
  return {
    x: 1,
    y: {
      a: 2,
      b: 'hello'
    }
  }
}
```
