### PR TITLE
Fixing silly bug in entrypoint due to parsing hosted URL as a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This changelog documents the changes between release versions.
 
 Changes to be included in the next upcoming releaase.
 
+## v0.11
+
+PR: https://github.com/hasura/ndc-typescript-deno/pull/59
+
+* Bugfix: Issue with unused argument being parsed as a file - Prevented invoking on deno.land
+
 ## v0.10
 
 PR: https://github.com/hasura/ndc-typescript-deno/pull/57

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -27,6 +27,7 @@ program.addCommand(inferCommand);
 // The commander library expects node style arguments that have
 // 'node' and the entrypoint as the first two arguments.
 // The node_style_args array makes Deno.args compatible.
-const node_style_args = [Deno.execPath(), path.fromFileUrl(import.meta.url), ...Deno.args];
+// The import.meta.url is used instead of a file, since it may be invoked from deno.land
+const node_style_args = [Deno.execPath(), import.meta.url, ...Deno.args];
 
 program.parseAsync(node_style_args).catch(console.error);


### PR DESCRIPTION
The value is never used anyway, so this was a bug that didn't even serve any purpose.

```diff
---const node_style_args = [Deno.execPath(), path.fromFileUrl(import.meta.url), ...Deno.args];
+++const node_style_args = [Deno.execPath(), import.meta.url, ...Deno.args];
```

Doesn't trigger when running against a local copy of the connector, but does occur when invoking from deno.land.

Causes the following:

```
> deno run -A --watch --check https://deno.land/x/hasura_typescript_connector@v0.10/mod.ts serve --configuratio
n ./config.json
Watcher Process started.
error: Uncaught TypeError: Must be a file URL.
    throw new TypeError("Must be a file URL.");
```

This wasn't caught in testing since it needs to be published before it can be invoked in a way that fails.