### PR TITLE
Use positional names for inline-types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This changelog documents the changes between release versions.
 
 Changes to be included in the next upcoming releaase.
 
+## v0.12
+
+PR: https://github.com/hasura/ndc-typescript-deno/pull/60
+
+* Use positional names for inline types
+
 ## v0.11
 
 PR: https://github.com/hasura/ndc-typescript-deno/pull/59

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -122,6 +122,7 @@ function find_type_name(names: TypeNames, name: string): string | undefined {
 
 function lookup_type_name(root_file: string, checker: ts.TypeChecker, names: TypeNames, name: string, ty: ts.Type): string {
   const type_str = checker.typeToString(ty);
+  // TODO: https://github.com/hasura/ndc-typescript-deno/issues/61 This regex check is janky.
   if(/{/.test(type_str)) {
     return name;
   }

--- a/src/test/data/inline_types.ts
+++ b/src/test/data/inline_types.ts
@@ -1,0 +1,5 @@
+
+
+export function bar(x: {a: number, b: string}): string {
+  return 'hello';
+}

--- a/src/test/inline_types_test.ts
+++ b/src/test/inline_types_test.ts
@@ -1,0 +1,77 @@
+
+import * as test    from "https://deno.land/std@0.202.0/assert/mod.ts";
+import * as path    from "https://deno.land/std@0.203.0/path/mod.ts";
+import * as infer   from '../infer.ts';
+
+Deno.test({ name: "Type Parameters",
+ ignore: false,
+ fn() {
+  const program_path = path.fromFileUrl(import.meta.resolve('./data/inline_types.ts'));
+  const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
+
+  const program_results = infer.programInfo(program_path, vendor_path, false);
+
+  // TODO: Currently broken since parameters aren't normalised
+
+  test.assertEquals(program_results, 
+    {
+      "schema": {
+        "scalar_types": {
+          "String": {
+            "aggregate_functions": {},
+            "comparison_operators": {},
+            "update_operators": {}
+          },
+          "Float": {
+            "aggregate_functions": {},
+            "comparison_operators": {},
+            "update_operators": {}
+          }
+        },
+        "object_types": {
+          "bar_arguments_x": {
+            "fields": {
+              "a": {
+                "type": {
+                  "type": "named",
+                  "name": "Float"
+                }
+              },
+              "b": {
+                "type": {
+                  "type": "named",
+                  "name": "String"
+                }
+              }
+            }
+          }
+        },
+        "collections": [],
+        "functions": [],
+        "procedures": [
+          {
+            "name": "bar",
+            "arguments": {
+              "x": {
+                "type": {
+                  "type": "named",
+                  "name": "bar_arguments_x"
+                }
+              }
+            },
+            "result_type": {
+              "type": "named",
+              "name": "String"
+            }
+          }
+        ]
+      },
+      "positions": {
+        "bar": [
+          "x"
+        ]
+      }
+    }
+  );
+
+}});


### PR DESCRIPTION
The recent v0.10 tag changed positional type names into qualified names matching the source names.

This failed to consider inline types, which (while possibly valid) would be better served as positional names.

This PR addresses this issue as seen with this program:

```typescript
export function bar(x: {a: number, b: string}): string {
  return 'hello';
}
```

corresponding to this change in schema:

```diff
        "object_types": {
---        "{ a: number; b: string; }": {
+++        "bar_arguments_x": {
```