### PR TITLE
Adding (currently ignored) test to verify behaviour of external dependency usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+
+.PHONY: help
+help:
+	@echo Targets:
+	@cat Makefile | grep '^[a-zA-Z]' | sed 's/^/  * /; s/://'
+
+test:
+	deno test -A src/test
+
+test-and-watch:
+	deno test -A --watch src/test
+
+serve:
+	@echo Note, this requires a config argument - Run the command directly.
+	deno run -A --watch --check src/mod.ts serve

--- a/src/test/data/external_dependencies.ts
+++ b/src/test/data/external_dependencies.ts
@@ -1,0 +1,9 @@
+
+import * as base64 from "https://denopkg.com/chiefbiiko/base64@v0.2.1/mod.ts";
+import * as emojify from "npm:node-emoji@2.1";
+
+export function test_deps(s: string): string {
+  const b64 = base64.fromUint8Array(new TextEncoder().encode(s));
+  const emo = emojify.emojify(":t-rex: :heart: NPM");
+  return `${b64} ${emo}`;
+}

--- a/src/test/external_dependencies_test.ts
+++ b/src/test/external_dependencies_test.ts
@@ -1,0 +1,29 @@
+
+import * as test    from "https://deno.land/std@0.202.0/assert/mod.ts";
+import * as path    from "https://deno.land/std@0.203.0/path/mod.ts";
+import * as infer   from '../infer.ts';
+
+// Skipped due to NPM dependency resolution not currently being supported.
+Deno.test({
+  name: "Inference",
+  ignore: true,
+  fn() {
+    const program_path = path.fromFileUrl(import.meta.resolve('./data/external_dependencies.ts'));
+    const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
+    const program_results = infer.programInfo(program_path, vendor_path, false);
+
+    test.assertEquals(program_results, {
+      positions: {
+      },
+      schema: {
+        scalar_types: {
+        },
+        object_types: {},
+        collections: [],
+        functions: [],
+        procedures: [
+        ],
+      }
+    });
+  }
+});


### PR DESCRIPTION
Deno doesn't currently support vendoring `npm:` sources, so this test will fail which is why it's currently ignored.