### PR TITLE
Refinement of validation algorithm

### DIFF
--- a/src/infer.ts
+++ b/src/infer.ts
@@ -74,12 +74,15 @@ function gql_name(n: string): string {
   return n.replace(/^[^a-zA-Z]/, '').replace(/[^0-9a-zA-Z]/g,'_');
 }
 
-function qualified_type_name(root_file: string, checker: ts.TypeChecker, t: any, names: TypeNames): string {
-  const symbol = t.getSymbol()!;
-  const type_str = checker.typeToString(t);
+function qualify_type_name(root_file: string, t: any, name: string): string {
+  let symbol = t.getSymbol();
 
   if(! symbol) {
-    throw new Error(`Couldn't find symbol for type ${type_str}`);
+    try {
+      symbol = t.types[0].getSymbol();
+    } catch(e) {
+      throw new Error(`Couldn't find symbol for type ${name}`);
+    }
   }
 
   const locations = symbol.declarations.map((d: any) => d.getSourceFile());
@@ -91,50 +94,16 @@ function qualified_type_name(root_file: string, checker: ts.TypeChecker, t: any,
     // If it is under the entrypoint's directory qualify with the subpath
     // Otherwise, use the minimum ancestor of the type's location to ensure non-conflict
     if(root_file == where) {
-      return type_str;
+      return name;
     } else if (short.length < where.length) {
-      return `${gql_name(short)}_${type_str}`;
+      return `${gql_name(short)}_${name}`;
     } else {
-      const split = where.split('/');
-      const len = split.length;
-      for(let i = len - 2; i >= 0; i--) {
-        const joined = split.slice(i, len).join('/');
-        const name = `${gql_name(joined)}_${type_str}`;
-        if(! find_type_name(names,name)) {
-          return name;
-        }
-      }
-      throw new Error(`Couldn't find any declarations for type ${type_str}`);
+      throw new Error(`Unsupported location for type ${name} in ${where}`);
     }
   }
 
-  throw new Error(`Couldn't find any declarations for type ${type_str}`);
+  throw new Error(`Couldn't find any declarations for type ${name}`);
 }
-
-function find_type_name(names: TypeNames, name: string): string | undefined {
-  for(const p of names) {
-    if(name == p.name) {
-      return p.name;
-    }
-  }
-  return;
-};
-
-function lookup_type_name(root_file: string, checker: ts.TypeChecker, names: TypeNames, name: string, ty: ts.Type): string {
-  const type_str = checker.typeToString(ty);
-  // TODO: https://github.com/hasura/ndc-typescript-deno/issues/61 This regex check is janky.
-  if(/{/.test(type_str)) {
-    return name;
-  }
-  for(const p of names) {
-    if(ty == p.type) {
-      return p.name;
-    }
-  }
-  const new_name = qualified_type_name(root_file, checker, ty, names);
-  names.push({type: ty, name: new_name});
-  return new_name;
-};
 
 function validate_type(root_file: string, checker: ts.TypeChecker, object_names: TypeNames, schema_response: sdk.SchemaResponse, name: string, ty: any, depth: number): sdk.Type {
   const type_str = checker.typeToString(ty);
@@ -148,6 +117,7 @@ function validate_type(root_file: string, checker: ts.TypeChecker, object_names:
   // PROMISE
   // TODO: https://github.com/hasura/ndc-typescript-deno/issues/32 There is no recursion that resolves inner promises.
   //       Nested promises should be resolved in the function definition.
+  // TODO: promises should not be allowed in parameters
   if (type_name == "Promise") {
     const inner_type = ty.resolvedTypeArguments[0];
     const inner_type_result = validate_type(root_file, checker, object_names, schema_response, name, inner_type, depth + 1);
@@ -155,15 +125,14 @@ function validate_type(root_file: string, checker: ts.TypeChecker, object_names:
   }
 
   // ARRAY
-  // TODO: https://github.com/hasura/ndc-typescript-deno/issues/33 There should be a library function that allows us to check this case
-  else if (type_name == "Array") {
+  if (checker.isArrayType(ty)) {
     const inner_type = ty.resolvedTypeArguments[0];
     const inner_type_result = validate_type(root_file, checker, object_names, schema_response, `Array_of_${name}`, inner_type, depth + 1);
     return { type: 'array', element_type: inner_type_result };
   }
 
-  // SCALAR
-  else if (scalar_mappings[type_name_lower]) {
+  // Named SCALAR
+  if (scalar_mappings[type_name_lower]) {
     const type_name_gql = scalar_mappings[type_name_lower];
     schema_response.scalar_types[type_name_gql] = no_ops;
     return { type: 'named', name: type_name_gql };
@@ -171,8 +140,9 @@ function validate_type(root_file: string, checker: ts.TypeChecker, object_names:
 
   // OBJECT
   // TODO: https://github.com/hasura/ndc-typescript-deno/issues/33 There should be a library function that allows us to check this case
-  else if (is_struct(ty)) {
-    const type_str_qualified = lookup_type_name(root_file, checker, object_names, name, ty);
+  const info = get_object_type_info(root_file, checker, ty, name);
+  if (info) {
+    const type_str_qualified = info.type_name; // lookup_type_name(root_file, checker, info, object_names, name, ty);
     
     // Shortcut recursion if the type has already been named
     if(schema_response.object_types[type_str_qualified]) {
@@ -180,8 +150,7 @@ function validate_type(root_file: string, checker: ts.TypeChecker, object_names:
     }
 
     schema_response.object_types[type_str_qualified] = Object(); // Break infinite recursion
-    const fields = Object.fromEntries(Array.from(ty.members, ([k, v]) => {
-      const field_type = checker.getTypeAtLocation(v.declarations[0].type);
+    const fields = Object.fromEntries(Array.from(info.members, ([k, field_type]) => {
       const field_type_validated = validate_type(root_file, checker, object_names, schema_response, `${name}_field_${k}`, field_type, depth + 1);
       return [k, { type: field_type_validated }];
     }));
@@ -190,7 +159,13 @@ function validate_type(root_file: string, checker: ts.TypeChecker, object_names:
     return { type: 'named', name: type_str_qualified}
   }
 
-  else if (type_name == "void") {
+  // TODO: We could potentially support classes, but only as return types, not as function arguments
+  if ((ty.objectFlags & ts.ObjectFlags.Class) !== 0) {
+    console.error(`class types are not supported: ${name}`);
+    error('validate_type failed');
+  }
+
+  if (ty === checker.getVoidType()) {
     console.error(`void functions are not supported: ${name}`);
     error('validate_type failed');
   }
@@ -202,11 +177,9 @@ function validate_type(root_file: string, checker: ts.TypeChecker, object_names:
   // }
 
   // UNHANDLED: Assume that the type is a scalar
-  else {
-    console.error(`Unable to validate type of ${name}: ${type_str} (${type_name}). Assuming that it is a scalar type.`);
-    schema_response.scalar_types[name] = no_ops;
-    return { type: 'named', name };
-  }
+  console.error(`Unable to validate type of ${name}: ${type_str} (${type_name}). Assuming that it is a scalar type.`);
+  schema_response.scalar_types[name] = no_ops;
+  return { type: 'named', name };
 }
 
 /**
@@ -258,6 +231,88 @@ function listing(prompt: string, positions: FunctionPositions, info: Array<sdk.F
 }
 
 /**
+ * Returns the flags associated with a type.
+ */
+function which_flags(flags_enum: Record<string, string | number>, value: number): string[] {
+  return Object
+    .keys(flags_enum)
+    .flatMap(k => {
+      const k_int = parseInt(k);
+      return isNaN(k_int)
+        ? []
+        : (value & k_int) !== 0
+          ? [flags_enum[k] as string]
+          : []
+    });
+}
+
+type ObjectTypeInfo = {
+  // The name of the type (not including generic type parameters)
+  type_name: string,
+  // Any type parameter types used with this type, useful for forming
+  // a closed generic name (eg IThing<string,number> could become IThing_string_number)
+  generic_parameter_types: readonly ts.Type[]
+  // The member properties of the object type. The types are
+  // concrete types after type parameter resolution
+  members: Map<string, ts.Type>
+}
+
+function get_members(checker: ts.TypeChecker, ty: ts.Type, member_names: string[]) {
+  return new Map(
+    member_names.map(name => [name, checker.getTypeOfSymbol(checker.getPropertyOfType(ty, name)!)])
+  )
+}
+
+function get_object_type_info(root_file: string, checker: ts.TypeChecker, ty: any, contextual_name: string): ObjectTypeInfo | null {
+  // Anonymous object type - this covers:
+  // - {a: number, b: string}
+  // - type Bar = { test: string }
+  // - type GenericBar<T> = { data: T }
+  if ((ty.objectFlags & ts.ObjectFlags.Anonymous) !== 0) {
+    const members = 
+      ty.aliasTypeArguments !== undefined
+        ? ty.target.members
+        : ty.members;
+    return {
+      type_name: qualify_type_name(root_file, ty, ty.aliasSymbol ? checker.typeToString(ty) : contextual_name),
+      generic_parameter_types: ty.aliasTypeArguments ?? [],
+      members: get_members(checker, ty, Array.from(members.keys())),
+    }
+  }
+  // Interface type - this covers:
+  // interface IThing { test: string }
+  else if ((ty.objectFlags & ts.ObjectFlags.Interface) !== 0) {
+    return {
+      type_name: ty.symbol.escapedName,
+      generic_parameter_types: [],
+      members: get_members(checker, ty, Array.from(ty.members.keys())),
+    }
+  } 
+  // Generic interface type - this covers:
+  // interface IGenericThing<T> { data: T }
+  else if ((ty.objectFlags & ts.ObjectFlags.Reference) !== 0 && (ty.target.objectFlags & ts.ObjectFlags.Interface) !== 0 && checker.isArrayType(ty) == false && ty.symbol.escapedName !== "Promise") {
+    return {
+      type_name: ty.symbol.escapedName,
+      generic_parameter_types: ty.typeArguments,
+      members: get_members(checker, ty, Array.from(ty.target.members.keys())),
+    }
+  }
+  // Intersection type - this covers:
+  // - { num: number } & Bar
+  // - type IntersectionObject = { wow: string } & Bar
+  // - type GenericIntersectionObject<T> = { data: T } & Bar
+  else if ((ty.flags & ts.TypeFlags.Intersection) !== 0) {
+    return {
+      type_name: qualify_type_name(root_file, ty, ty.aliasSymbol ? checker.typeToString(ty) : contextual_name),
+      generic_parameter_types: ty.aliasTypeArguments ?? [],
+      members: new Map(ty.resolvedProperties.map((symbol: ts.Symbol) => [symbol.name, checker.getTypeOfSymbol(symbol)])),
+    }
+  }
+
+  return null;
+}
+
+/**
  * This wraps the exception variant programInfoException and calls Deno.exit(1) on error.
  * @param filename_arg 
  * @param vendor_arg 
@@ -271,6 +326,7 @@ export function programInfo(filename_arg?: string, vendor_arg?: string, perform_
     listing('Procedures', info.positions, info.schema.procedures)
     return info;
   } catch(e) {
+    console.error(e.stack);
     console.error(e.message);
     Deno.exit(1);
   }

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -326,8 +326,8 @@ export function programInfo(filename_arg?: string, vendor_arg?: string, perform_
     listing('Procedures', info.positions, info.schema.procedures)
     return info;
   } catch(e) {
-    console.error(e.stack);
     console.error(e.message);
+    // console.error(e.stack);
     Deno.exit(1);
   }
 }

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -22,11 +22,6 @@ export type ProgramInfo = {
   positions: FunctionPositions
 }
 
-// TODO: https://github.com/hasura/ndc-typescript-deno/issues/31 Specialise the any to ty.Type or something similar
-function is_struct(ty: any): boolean {
-  return (ty?.members?.size || 0) > 0;
-}
-
 function mapObject<I, O>(obj: {[key: string]: I}, fn: ((key: string, value: I) => [string, O])): {[key: string]: O} {
   const keys: Array<string> = Object.keys(obj);
   const result: {[key: string]: O} = {};

--- a/src/test/classes_test.ts
+++ b/src/test/classes_test.ts
@@ -1,0 +1,13 @@
+
+import * as test    from "https://deno.land/std@0.202.0/assert/mod.ts";
+import * as path    from "https://deno.land/std@0.203.0/path/mod.ts";
+import * as infer   from '../infer.ts';
+
+// Classes are currently not supoported and should throw an error
+Deno.test("Complex Dependency", () => {
+  const program_path = path.fromFileUrl(import.meta.resolve('./data/classes.ts'));
+  const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
+  test.assertThrows(() => {
+    infer.programInfo(program_path, vendor_path, false);
+  })
+});

--- a/src/test/complex_dependency_test.ts
+++ b/src/test/complex_dependency_test.ts
@@ -1,0 +1,18 @@
+
+import * as test    from "https://deno.land/std@0.202.0/assert/mod.ts";
+import * as path    from "https://deno.land/std@0.203.0/path/mod.ts";
+import * as infer   from '../infer.ts';
+
+// This previously went into an infinite loop
+Deno.test("Inference on Dependency", () => {
+  const program_path = path.fromFileUrl(import.meta.resolve('./data/infinite_loop.ts'));
+  const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
+  const program_results = infer.programInfo(program_path, vendor_path, false);
+  test.assertEquals(program_results.schema.procedures, [
+    {
+      name: "infinite_loop",
+      arguments: {},
+      result_type: { type: "named", name: "Response" }
+    }
+  ]);
+});

--- a/src/test/complex_dependency_test.ts
+++ b/src/test/complex_dependency_test.ts
@@ -3,7 +3,7 @@ import * as test    from "https://deno.land/std@0.202.0/assert/mod.ts";
 import * as path    from "https://deno.land/std@0.203.0/path/mod.ts";
 import * as infer   from '../infer.ts';
 
-// This previously went into an infinite loop
+// This program omits its return type and it is inferred via the 'fetch' dependency.
 Deno.test("Inference on Dependency", () => {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/infinite_loop.ts'));
   const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));

--- a/src/test/data/classes.ts
+++ b/src/test/data/classes.ts
@@ -1,0 +1,10 @@
+
+
+class MyClass {
+}
+
+export function bar(
+  clazz: MyClass
+  ): string {
+  return 'hello';
+}

--- a/src/test/data/validation_algorithm_update.ts
+++ b/src/test/data/validation_algorithm_update.ts
@@ -1,0 +1,45 @@
+
+// Placeholder index.ts to allow CI to run against functions volume
+
+type Bar = {
+  test: string
+}
+
+type GenericBar<T> = {
+  data: T
+}
+
+interface IThing {
+  prop: string
+}
+
+interface IGenericThing<T> {
+  data: T
+}
+
+type IntersectionObject = { wow: string } & Bar
+
+type GenericIntersectionObject<T> = { data: T } & Bar
+
+type AliasedString = string;
+
+type GenericScalar<T> = GenericScalar2<T>
+type GenericScalar2<T> = T
+
+export function bar(
+  string: string, 
+  aliasedString: AliasedString,
+  genericScalar: GenericScalar<string>,
+  array: string[], 
+  promise: Promise<string>, 
+  anonObj: {a: number, b: string}, 
+  aliasedObj: Bar, 
+  genericAliasedObj: GenericBar<string>, 
+  interfce: IThing, 
+  genericInterface: IGenericThing<string>, 
+  aliasedIntersectionObj: IntersectionObject, 
+  anonIntersectionObj: {num:number} & Bar,
+  genericIntersectionObj: GenericIntersectionObject<string>,
+  ): string {
+  return 'hello';
+}

--- a/src/test/data/void_types.ts
+++ b/src/test/data/void_types.ts
@@ -1,0 +1,6 @@
+
+// Infinite loop void bug: https://github.com/hasura/ndc-typescript-deno/issues/45
+
+export function void_function(): void {
+  return
+}

--- a/src/test/type_parameters_test.ts
+++ b/src/test/type_parameters_test.ts
@@ -4,7 +4,7 @@ import * as path    from "https://deno.land/std@0.203.0/path/mod.ts";
 import * as infer   from '../infer.ts';
 
 Deno.test({ name: "Type Parameters",
- ignore: true,
+ ignore: false,
  fn() {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/type_parameters.ts'));
   const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
@@ -31,7 +31,7 @@ Deno.test({ name: "Type Parameters",
             },
             y: {
               type: {
-                name: "bar_output_field_y",
+                name: "Foo",
                 type: "named",
               },
             },
@@ -47,7 +47,7 @@ Deno.test({ name: "Type Parameters",
             },
             b: {
               type: {
-                name: "Float",
+                name: "String",
                 type: "named",
               },
             },

--- a/src/test/validation_algorithm_test.ts
+++ b/src/test/validation_algorithm_test.ts
@@ -1,0 +1,247 @@
+
+import * as test    from "https://deno.land/std@0.202.0/assert/mod.ts";
+import * as path    from "https://deno.land/std@0.203.0/path/mod.ts";
+import * as infer   from '../infer.ts';
+
+Deno.test({ name: "Type Parameters",
+ ignore: false,
+ fn() {
+  const program_path = path.fromFileUrl(import.meta.resolve('./data/validation_algorithm_update.ts'));
+  const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
+
+  const program_results = infer.programInfo(program_path, vendor_path, false);
+
+  test.assertEquals(program_results, {
+    positions: {
+      bar: [
+        "string",
+        "aliasedString",
+        "genericScalar",
+        "array",
+        "promise",
+        "anonObj",
+        "aliasedObj",
+        "genericAliasedObj",
+        "interfce",
+        "genericInterface",
+        "aliasedIntersectionObj",
+        "anonIntersectionObj",
+        "genericIntersectionObj",
+      ],
+    },
+    schema: {
+      collections: [],
+      functions: [],
+      object_types: {
+        "GenericBar<string>": {
+          fields: {
+            data: {
+              type: {
+                name: "String",
+                type: "named",
+              },
+            },
+          },
+        },
+        "GenericIntersectionObject<string>": {
+          fields: {
+            data: {
+              type: {
+                name: "String",
+                type: "named",
+              },
+            },
+            test: {
+              type: {
+                name: "String",
+                type: "named",
+              },
+            },
+          },
+        },
+        Bar: {
+          fields: {
+            test: {
+              type: {
+                name: "String",
+                type: "named",
+              },
+            },
+          },
+        },
+        IGenericThing: {
+          fields: {
+            data: {
+              type: {
+                name: "String",
+                type: "named",
+              },
+            },
+          },
+        },
+        IThing: {
+          fields: {
+            prop: {
+              type: {
+                name: "String",
+                type: "named",
+              },
+            },
+          },
+        },
+        IntersectionObject: {
+          fields: {
+            test: {
+              type: {
+                name: "String",
+                type: "named",
+              },
+            },
+            wow: {
+              type: {
+                name: "String",
+                type: "named",
+              },
+            },
+          },
+        },
+        bar_arguments_anonIntersectionObj: {
+          fields: {
+            num: {
+              type: {
+                name: "Float",
+                type: "named",
+              },
+            },
+            test: {
+              type: {
+                name: "String",
+                type: "named",
+              },
+            },
+          },
+        },
+        bar_arguments_anonObj: {
+          fields: {
+            a: {
+              type: {
+                name: "Float",
+                type: "named",
+              },
+            },
+            b: {
+              type: {
+                name: "String",
+                type: "named",
+              },
+            },
+          },
+        },
+      },
+      procedures: [
+        {
+          arguments: {
+            aliasedIntersectionObj: {
+              type: {
+                name: "IntersectionObject",
+                type: "named",
+              },
+            },
+            aliasedObj: {
+              type: {
+                name: "Bar",
+                type: "named",
+              },
+            },
+            aliasedString: {
+              type: {
+                name: "String",
+                type: "named",
+              },
+            },
+            anonIntersectionObj: {
+              type: {
+                name: "bar_arguments_anonIntersectionObj",
+                type: "named",
+              },
+            },
+            anonObj: {
+              type: {
+                name: "bar_arguments_anonObj",
+                type: "named",
+              },
+            },
+            array: {
+              type: {
+                element_type: {
+                  name: "String",
+                  type: "named",
+                },
+                type: "array",
+              },
+            },
+            genericAliasedObj: {
+              type: {
+                name: "GenericBar<string>",
+                type: "named",
+              },
+            },
+            genericInterface: {
+              type: {
+                name: "IGenericThing",
+                type: "named",
+              },
+            },
+            genericIntersectionObj: {
+              type: {
+                name: "GenericIntersectionObject<string>",
+                type: "named",
+              },
+            },
+            genericScalar: {
+              type: {
+                name: "String",
+                type: "named",
+              },
+            },
+            interfce: {
+              type: {
+                name: "IThing",
+                type: "named",
+              },
+            },
+            promise: {
+              type: {
+                name: "String",
+                type: "named",
+              },
+            },
+            string: {
+              type: {
+                name: "String",
+                type: "named",
+              },
+            },
+          },
+          name: "bar",
+          result_type: {
+            name: "String",
+            type: "named",
+          },
+        },
+      ],
+      scalar_types: {
+        Float: {
+          aggregate_functions: {},
+          comparison_operators: {},
+          update_operators: {},
+        },
+        String: {
+          aggregate_functions: {},
+          comparison_operators: {},
+          update_operators: {},
+        },
+      }
+    }
+  });
+}});

--- a/src/test/void_test.ts
+++ b/src/test/void_test.ts
@@ -6,10 +6,9 @@ import * as infer   from '../infer.ts';
 // NOTE: It would be good to have explicit timeout for this
 // See: https://github.com/denoland/deno/issues/11133
 // Test bug: https://github.com/hasura/ndc-typescript-deno/issues/45
-Deno.test("Void Types", () => {
-  const program_path = path.fromFileUrl(import.meta.resolve('./data/infinite_loop.ts'));
+Deno.test("Complex Dependency", () => {
+  const program_path = path.fromFileUrl(import.meta.resolve('./data/void_types.ts'));
   const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
-
   test.assertThrows(() => {
     infer.programInfo(program_path, vendor_path, false);
   })

--- a/src/test/void_test.ts
+++ b/src/test/void_test.ts
@@ -6,7 +6,7 @@ import * as infer   from '../infer.ts';
 // NOTE: It would be good to have explicit timeout for this
 // See: https://github.com/denoland/deno/issues/11133
 // Test bug: https://github.com/hasura/ndc-typescript-deno/issues/45
-Deno.test("Complex Dependency", () => {
+Deno.test("Inferred Dependency Based Result Type", () => {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/void_types.ts'));
   const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
   test.assertThrows(() => {


### PR DESCRIPTION
Updating the validation algorithm to perform more robust validation of generic types.

Thanks to @daniel-chambers for the POC of the flag based object type function.

Fixes: https://github.com/hasura/ndc-typescript-deno/issues/61 - Use a better check for inline object type detection
Fixes: https://github.com/hasura/ndc-typescript-deno/issues/33 - Detect Object and Array scenarios using TS library functions
Fixes: https://github.com/hasura/ndc-typescript-deno/issues/45 - (Already Closed) - Infinite loop for certain function definitions
Fixes: https://github.com/hasura/ndc-typescript-deno/issues/51 - [Inferring result for non-annotated functions.](https://github.com/hasura/ndc-typescript-deno/issues/51)
Fixes: https://github.com/hasura/ndc-typescript-deno/issues/31 - Find a better implementation of is_struct that is type aware
