### PR TITLE
`preVendor: true` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ This changelog documents the changes between release versions.
 
 Changes to be included in the next upcoming releaase.
 
+## v0.16
+
+Prevendoring by default.
+
+PR: https://github.com/hasura/ndc-typescript-deno/pull/74
+
+* Using defaults of `{"preVendor": true}` to minimise setup required for development
+
 ## v0.15
 
 Updating TypeScript target version from ES2017 to ES2022.

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -41,7 +41,7 @@ export const CONFIGURATION_SCHEMA: JSONSchemaObject = {
       type: 'string'
     },
     preVendor: {
-      description: 'Perform vendoring prior to inference in a sub-process (default: false)',
+      description: 'Perform vendoring prior to inference in a sub-process (default: true)',
       type: 'boolean'
     },
     schemaMode:  {
@@ -250,7 +250,11 @@ export const connector: sdk.Connector<Configuration, Configuration, State> = {
 
   // TODO: https://github.com/hasura/ndc-typescript-deno/issues/27 Make this add in the defaults
   update_configuration(configuration: Configuration): Promise<Configuration> {
-    return Promise.resolve(configuration);
+    const defaults = {
+      preVendor: true,
+    }
+    const response = { ...defaults, ...configuration }
+    return Promise.resolve(response);
   },
 
   validate_raw_configuration(configuration: Configuration): Promise<Configuration> {

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -37,7 +37,7 @@ then
 fi
 
 # The config is always the same for `connector create`
-echo '{"functions": "/functions/index.ts", "vendor": "/functions/vendor", "schemaMode": "READ", "schemaLocation": "/functions/schema.json"}' \
+echo '{"functions": "/functions/index.ts", "vendor": "/functions/vendor", "preVendor": false, "schemaMode": "READ", "schemaLocation": "/functions/schema.json"}' \
   > /config.json
 
 deno run \


### PR DESCRIPTION
In order to allow users to specify an empty object config, we should prevendor by default so dependencies 'just work'.

Fixes: https://github.com/hasura/ndc-typescript-deno/issues/71