### PR TITLE
Fixing implementation error for configuration defaults: `preVendor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ This changelog documents the changes between release versions.
 
 Changes to be included in the next upcoming releaase.
 
+## v0.17
+
+Fixing issue with preVendor default.
+
+PR: https://github.com/hasura/ndc-typescript-deno/pull/76
+
+* Was only applying the default during user-interactive config flows
+
 ## v0.16
 
 Prevendoring by default.

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -250,15 +250,15 @@ export const connector: sdk.Connector<Configuration, Configuration, State> = {
 
   // TODO: https://github.com/hasura/ndc-typescript-deno/issues/27 Make this add in the defaults
   update_configuration(configuration: Configuration): Promise<Configuration> {
+    return Promise.resolve(configuration);
+  },
+
+  validate_raw_configuration(configuration: Configuration): Promise<Configuration> {
     const defaults = {
       preVendor: true,
     }
     const response = { ...defaults, ...configuration }
     return Promise.resolve(response);
-  },
-
-  validate_raw_configuration(configuration: Configuration): Promise<Configuration> {
-    return Promise.resolve(configuration);
   },
 
   get_schema(config: Configuration): Promise<sdk.SchemaResponse> {


### PR DESCRIPTION
Previous implementation of vendor defaults was incorrect: https://github.com/hasura/ndc-typescript-deno/pull/74

This PR addresses the issue by not requiring defaulting to occur in the configuration step.