### PR TITLE
Improved `deno run --watch` support, watch support inside Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 target
 Dockerfile
 .dockerignore
+.gitkeep

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Setup Deno
         # uses: denoland/setup-deno@v1
-        uses: denoland/setup-deno@61fe2df320078202e33d7d5ad347e7dcfa0e8f31  # v1.1.2
+        uses: denoland/setup-deno@0df5d9c641efdff149993c321fc27c11c5df8623  # v1.1.3
         with:
           deno-version: v1.x
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This changelog documents the changes between release versions.
 
 ## main
 
-Changes to be included in the next upcoming releaase.
+Changes to be included in the next upcoming release.
 
 ## v0.19
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM denoland/deno:alpine-1.38.3
 
 RUN mkdir /etc/connector
 COPY ./src /app
+RUN deno cache /app/mod.ts
+
 COPY ./functions /functions/src
-WORKDIR /functions/src
 
 # Pre-cache inference results and dependencies
 RUN PRECACHE_ONLY=true /app/entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY ./functions /functions/src
 WORKDIR /functions/src
 
 # Pre-cache inference results and dependencies
-RUN EARLY_ENTRYPOINT_EXIT=true /app/entrypoint.sh
+RUN PRECACHE_ONLY=true /app/entrypoint.sh
 
 ENTRYPOINT [ "/app/entrypoint.sh" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
 FROM denoland/deno:alpine-1.37.1
 
+RUN mkdir /etc/connector
 COPY ./src /app
-COPY ./functions /functions 
-WORKDIR /functions
-
-RUN ls /app
+COPY ./functions /functions/src
+WORKDIR /functions/src
 
 # Pre-cache inference results and dependencies
-RUN EARLY_ENTRYPOINT_EXIT=true sh /app/entrypoint.sh
+RUN EARLY_ENTRYPOINT_EXIT=true /app/entrypoint.sh
 
-ENTRYPOINT [ "sh", "/app/entrypoint.sh" ]
+ENTRYPOINT [ "/app/entrypoint.sh" ]
 
 CMD [ ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:alpine-1.37.1
+FROM denoland/deno:alpine-1.38.3
 
 RUN mkdir /etc/connector
 COPY ./src /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM denoland/deno:alpine-1.38.3
 
-RUN mkdir /etc/connector
 COPY ./src /app
 RUN deno cache /app/mod.ts
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ WORKDIR /functions/src
 # Pre-cache inference results and dependencies
 RUN PRECACHE_ONLY=true /app/entrypoint.sh
 
+EXPOSE 8080
+
 ENTRYPOINT [ "/app/entrypoint.sh" ]
 
 CMD [ ]

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ In order to develop your functions locally the following is the recommended prac
   * Make sure to .gitignore your computed `vendor` files.
 * Start the connector
 ```sh
-deno run -A --watch --check https://deno.land/x/hasura_typescript_connector/mod.ts serve --configuration ./config.json
+deno run -A --watch=./functions --check https://deno.land/x/hasura_typescript_connector/mod.ts serve --configuration ./config.json
 ```
 * (Optionally) Add a test-suite for your functions. See [Deno Testing Basics](https://docs.deno.com/runtime/manual/basics/testing).
 
@@ -331,7 +331,7 @@ In order to perform local development on this codebase:
 
 * Check out the repository: `git clone https://github.com/hasura/ndc-typescript-deno.git`
 * This assumes that you will be testing against function in `./functions`
-* Serve your functions with `deno run -A --watch --check ./src/mod.ts serve --configuration <(echo '{"functions": "./functions/index.ts", "vendor": "./vendor", "schemaMode": "INFER"}')`
+* Serve your functions with `deno run -A --watch=./functions --check ./src/mod.ts serve --configuration <(echo '{"functions": "./functions/index.ts", "vendor": "./vendor", "schemaMode": "INFER"}')`
 * The connector should now be running on localhost:8100 and respond to any changes to the your functions and the connector source
 * Use the `hasura3` tunnel commands to reference this connector from a Hasura Cloud project
 

--- a/README.md
+++ b/README.md
@@ -2,21 +2,21 @@
 
 ![image](https://github.com/hasura/ndc-typescript-deno/assets/92299/9f139964-d0ed-4c92-b01f-9fda255717d4)
 
-The Typescript (Deno) Connector allows a running connector to be inferred from a Typescript file (optionally with dependencies).
+The TypeScript (Deno) Connector allows a running connector to be inferred from a TypeScript file (optionally with dependencies).
 
 ![image](https://github.com/hasura/ndc-typescript-deno/assets/92299/fb7f4afd-0302-432b-b7ce-3cc7d1f3546b)
 
 Useful Links:
 
-* [Typescript Deno Connector on the NDC Hub](https://hasura.io/connectors/typescript-deno)
-* [Typescript Deno Connector on deno.com](https://deno.land/x/hasura_typescript_connector)
+* [TypeScript Deno Connector on the NDC Hub](https://hasura.io/connectors/typescript-deno)
+* [TypeScript Deno Connector on deno.com](https://deno.land/x/hasura_typescript_connector)
 * [Hasura V3 Documentation](https://hasura.io/docs/3.0)
 * [Hasura CLI](https://github.com/hasura/v3-cli#hasura-v3-cli)
 * [CLI Connector Plugin](https://hasura.io/docs/latest/hasura-cli/connector-plugin/)
 * [Hasura VSCode Extension](https://marketplace.visualstudio.com/items?itemName=HasuraHQ.hasura)
 * [Deno](https://deno.com)
 * [Native Data Connector Specification](https://hasura.github.io/ndc-spec/)
-* [Typescript NDC SDK](https://github.com/hasura/ndc-sdk-typescript/)
+* [TypeScript NDC SDK](https://github.com/hasura/ndc-sdk-typescript/)
 * [DDN Limited Alpha Access Form](https://forms.gle/zHTrVEbsQoBK8ecr5)
 
 
@@ -24,7 +24,7 @@ Useful Links:
 
 The connector runs in the following manner:
 
-* Typescript sources are assembled (with `index.ts` acting as your interface definition)
+* TypeScript sources are assembled (with `index.ts` acting as your interface definition)
 * Dependencies are fetched
 * Inference is performed and made available via the `/schema` endpoint
 * Functions are served via the connector protocol
@@ -54,7 +54,7 @@ Once the Hasura DDN is generally available this will no longer be required.
 Your functions should be organised into a directory with one file acting as the entrypoint.
 
 <details>
-<summary> An example Typescript entrypoint: </summary>
+<summary> An example TypeScript entrypoint: </summary>
 
 ```typescript
 
@@ -123,7 +123,6 @@ Limitations:
 * All numbers are exported as `Float`s
 * Unrecognised types will become opaque scalars, for example: union types.
 * Optional object fields are not currently supported
-* Complex input types are supported by the connector, but are not supported in "commands" in Hasura3 projects
 * Functions can be executed via both the `/query` and `/mutation` endpoints
 * Conflicting type names in dependencies will be namespaced with their relative path
 * Generic type parameters will be treated as scalars when referenced
@@ -145,26 +144,15 @@ In order to develop your functions locally the following is the recommended prac
 {
   "functions": "./functions/index.ts",
   "vendor": "./vendor",
-  "preVendor": true,
   "schemaMode": "INFER"
 }
 ```
-* (Optionally) If you want your development vendor and inference resources to be used to speed up deployment, add the following to your `./config.json`:
-  ```json
-  {
-    "functions": "./functions/index.ts",
-    "vendor": "./functions/vendor",
-    "preVendor": true,
-    "schemaLocation": "./functions/schema.json",
-    "schemaMode": "INFER"
-  }
-  ```
-  * Make sure to .gitignore your computed `vendor` and `schema.json` files.
+  * Make sure to .gitignore your computed `vendor` files.
 * Start the connector
 ```sh
 deno run -A --watch --check https://deno.land/x/hasura_typescript_connector/mod.ts serve --configuration ./config.json
 ```
-* (Optionally) Add a test-suite to your functions. See [Deno Testing Basics](https://docs.deno.com/runtime/manual/basics/testing).
+* (Optionally) Add a test-suite for your functions. See [Deno Testing Basics](https://docs.deno.com/runtime/manual/basics/testing).
 
 
 ## Config Format
@@ -172,25 +160,25 @@ deno run -A --watch --check https://deno.land/x/hasura_typescript_connector/mod.
 The configuration object has the following properties:
 
 ```
-  functions      (string): Location of your functions entrypoint (default: ./functions/index.ts)
+  functions      (string): Location of your functions entrypoint
   vendor         (string): Location of dependencies vendor folder (optional)
-  preVendor     (boolean): Perform vendoring prior to inference in a sub-process (default: false)
-  schemaMode     (string): INFER the schema from your functions, or READ it from a file.
-  schemaLocation (string): Location of your schema file. schemaMode=READ reads the file, schemaMode=INFER writes the file (optional)
+  preVendor     (boolean): Perform vendoring prior to inference in a sub-process (default: true)
+  schemaMode     (string): INFER the schema from your functions, or READ it from a file. (default: INFER)
+  schemaLocation (string): Location of your schema file. schemaMode=READ reads the file (required), schemaMode=INFER writes the file (optional)
 ```
 
 NOTE: When deploying the connector with the `connector create` command your config is currently replaced with:
 
-```
+```json
 {
-  "functions": "/functions/index.ts",
+  "functions": "/functions/src/index.ts",
   "vendor": "/functions/vendor",
   "schemaMode": "READ",
   "schemaLocation": "/functions/schema.json"
 }
 ```
 
-This means that your functions volume will have to be mounted to `/functions`.
+This means that your functions volume will have to be mounted to `/functions/src`.
 
 ## Deployment for Hasura Users
 
@@ -203,7 +191,7 @@ You will need:
 
 Create the connector:
 
-```
+```bash
 hasura3 connector create my-cool-connector:v1 \
   --github-repo-url https://github.com/hasura/ndc-typescript-deno/tree/main \
   --config-file <(echo '{}') \
@@ -220,7 +208,7 @@ Monitor the deployment status by name - This will indicate in-progress, complete
 List all your connectors with their deployed URLs:
 
 > hasura3 connector list
- 
+
 View logs from your running connector:
 
 > hasura3 connector logs my-cool-connector:v1
@@ -343,7 +331,7 @@ In order to perform local development on this codebase:
 
 * Check out the repository: `git clone https://github.com/hasura/ndc-typescript-deno.git`
 * This assumes that you will be testing against function in `./functions`
-* Serve your functions with `deno run -A --watch --check ./src/mod.ts serve --configuration <(echo '{"functions": "./functions/index.ts", "vendor": "./functions/vendor", "schemaMode": "INFER"}')`
+* Serve your functions with `deno run -A --watch --check ./src/mod.ts serve --configuration <(echo '{"functions": "./functions/index.ts", "vendor": "./vendor", "schemaMode": "INFER"}')`
 * The connector should now be running on localhost:8100 and respond to any changes to the your functions and the connector source
 * Use the `hasura3` tunnel commands to reference this connector from a Hasura Cloud project
 

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -1,6 +1,0 @@
-
-// Placeholder index.ts to allow CI to run against functions volume
-
-export function hello(): string {
-  return 'hello world';
-}

--- a/src/README.md
+++ b/src/README.md
@@ -1,8 +1,8 @@
-# Hasura NDC Typescript (Deno) Connector
+# Hasura NDC TypeScript (Deno) Connector
 
 ![image](https://github.com/hasura/ndc-typescript-deno/assets/92299/9f139964-d0ed-4c92-b01f-9fda255717d4)
 
-The Typescript (Deno) Connector allows a running connector to be inferred from a Typescript file (optionally with dependencies).
+The TypeScript (Deno) Connector allows a running connector to be inferred from a TypeScript file (optionally with dependencies).
 
 ![image](https://github.com/hasura/ndc-typescript-deno/assets/92299/fb7f4afd-0302-432b-b7ce-3cc7d1f3546b)
 
@@ -19,14 +19,13 @@ Once your project is set up, run locally with:
 {
   "functions": "./functions/index.ts",
   "vendor": "./vendor",
-  "preVendor": true,
   "schemaMode": "INFER"
 }
 
 > deno run -A --watch --check https://deno.land/x/hasura_typescript_connector/mod.ts serve --configuration ./config.json
 ```
 
-## Typescript Functions Format
+## TypeScript Functions Format
 
 Your functions should be organised into a directory with one file acting as the entrypoint.
 

--- a/src/README.md
+++ b/src/README.md
@@ -22,7 +22,7 @@ Once your project is set up, run locally with:
   "schemaMode": "INFER"
 }
 
-> deno run -A --watch --check https://deno.land/x/hasura_typescript_connector/mod.ts serve --configuration ./config.json
+> deno run -A --watch=./functions --check https://deno.land/x/hasura_typescript_connector/mod.ts serve --configuration ./config.json
 ```
 
 ## TypeScript Functions Format

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -7,8 +7,8 @@ import { FunctionPositions, ProgramInfo, programInfo, Struct } from "./infer.ts"
 import { resolve } from "https://deno.land/std@0.208.0/path/mod.ts";
 import { JSONSchemaObject } from "npm:@json-schema-tools/meta-schema";
 
-import * as sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.4';
-export * as sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.4';
+import * as sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.5';
+export * as sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.5';
 
 export type State = {
   functions: any

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -1,6 +1,6 @@
 
 import { FunctionPositions, ProgramInfo, programInfo, Struct } from "./infer.ts";
-import { resolve } from "https://deno.land/std@0.203.0/path/mod.ts";
+import { resolve } from "https://deno.land/std@0.208.0/path/mod.ts";
 import { JSONSchemaObject } from "npm:@json-schema-tools/meta-schema";
 
 import * as sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.4';
@@ -68,8 +68,6 @@ type InferenceConfig = {
   vendorDir: string,
   preVendor: boolean,
 }
-
-
 
 export const CAPABILITIES_RESPONSE: sdk.CapabilitiesResponse = {
   versions: "^0.1.0",

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -1,3 +1,7 @@
+/**
+ * Implementation of the Connector interface for Deno connector.
+ * Using https://github.com/hasura/ndc-qdrant/blob/main/src/index.ts as an example.
+ */
 
 import { FunctionPositions, ProgramInfo, programInfo, Struct } from "./infer.ts";
 import { resolve } from "https://deno.land/std@0.208.0/path/mod.ts";
@@ -5,11 +9,6 @@ import { JSONSchemaObject } from "npm:@json-schema-tools/meta-schema";
 
 import * as sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.4';
 export * as sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.4';
-
-/**
- * Implementation of the Connector interface for Deno connector.
- * Using https://github.com/hasura/ndc-qdrant/blob/main/src/index.ts as an example.
- */
 
 export type State = {
   functions: any
@@ -88,8 +87,8 @@ type Payload<X> = {
 /**
  * Performs analysis on the supplied program.
  * Expects that if there are dependencies then they will have been vendored.
- * 
- * @param cmdObj 
+ *
+ * @param cmdObj
  * @returns Schema and argument position information
  */
 export function getInfo(cmdObj: InferenceConfig): ProgramInfo {
@@ -128,10 +127,10 @@ export function getInfo(cmdObj: InferenceConfig): ProgramInfo {
  * Performs invocation of the requested function.
  * Assembles the arguments into the correct order.
  * This doesn't catch any exceptions.
- * 
- * @param functions 
- * @param positions 
- * @param payload 
+ *
+ * @param functions
+ * @param positions
+ * @param payload
  * @returns the result of invocation with no wrapper
  */
 async function invoke(functions: any, positions: FunctionPositions, payload: Payload<unknown>): Promise<any> {
@@ -149,9 +148,9 @@ async function invoke(functions: any, positions: FunctionPositions, payload: Pay
 /**
  * This takes argument position information and a payload of function
  * and named arguments and returns the correctly ordered arguments ready to be applied.
- * 
- * @param functions 
- * @param payload 
+ *
+ * @param functions
+ * @param payload
  * @returns An array of the function's arguments in the definition order
  */
 function reposition<X>(functions: FunctionPositions, payload: Payload<X>): Array<X> {
@@ -262,8 +261,11 @@ export const connector: sdk.Connector<RawConfiguration, Configuration, State> = 
   },
 
   validate_raw_configuration(configuration: RawConfiguration): Promise<Configuration> {
+    if (configuration.functions.trim() === "") {
+      throw new sdk.BadRequest("'functions' must be set to the location of the TypeScript file that contains your functions")
+    }
     if (configuration.schemaMode === "READ" && !configuration.schemaLocation) {
-      throw new sdk.BadRequest("schemaLocation must be set if schemaMode is READ");
+      throw new sdk.BadRequest("'schemaLocation' must be set if 'schemaMode' is READ");
     }
     const inferenceConfig: InferenceConfig = {
       functions: resolve(configuration.functions),

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -42,7 +42,7 @@ fi
 
 if [[ "$WATCH" == "1" || "$WATCH" == "true" ]]
 then
-  DENO_PARAMS="--watch --no-clear-screen"
+  DENO_PARAMS="--watch=/functions/src --no-clear-screen"
   echo '{"functions": "/functions/src/index.ts", "vendor": "/functions/vendor", "preVendor": true, "schemaMode": "INFER" }' \
     > /etc/connector-config.json
 

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -30,7 +30,7 @@ else
       ./src/index.ts >schema.json
 fi
 
-if [ "$EARLY_ENTRYPOINT_EXIT" ]
+if [ "$PRECACHE_ONLY" ]
 then
   echo "Thanks for running pre-caching - Please come again soon!"
   exit 0

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -10,12 +10,17 @@ set -e
 
 cd /functions
 
+if [ ! -f ./src/index.ts ]
+then
+  echo "No /functions/src/index.ts found - Please place your functions in /functions/src"
+  exit 0
+fi
+
 if [ -d vendor ]
 then
   echo "found existing vendor results"
 else
   deno vendor --node-modules-dir --vendor /functions/vendor -f ./src/index.ts
-  deno vendor -f /app/mod.ts
 fi
 
 if [ -f schema.json ]
@@ -24,7 +29,6 @@ then
 else
   deno run \
     --allow-env --allow-sys --allow-read --allow-net --allow-write \
-    --import-map ./vendor/import_map.json \
     /app/mod.ts infer \
       --vendor /functions/vendor \
       ./src/index.ts >schema.json
@@ -40,12 +44,12 @@ if [[ "$WATCH" == "1" || "$WATCH" == "true" ]]
 then
   DENO_PARAMS="--watch --no-clear-screen"
   echo '{"functions": "/functions/src/index.ts", "vendor": "/functions/vendor", "preVendor": true, "schemaMode": "INFER" }' \
-    > /etc/connector/config.json
+    > /etc/connector/hardcoded-config.json
 
 else
-  DENO_PARAMS="--import-map ./vendor/import_map.json"
+  DENO_PARAMS=""
   echo '{"functions": "/functions/src/index.ts", "vendor": "/functions/vendor", "preVendor": false, "schemaMode": "READ", "schemaLocation": "/functions/schema.json"}' \
-    > /etc/connector/config.json
+    > /etc/connector/hardcoded-config.json
 fi
 
 deno run \
@@ -53,4 +57,4 @@ deno run \
   $DENO_PARAMS \
   /app/mod.ts serve \
   --port 8080 \
-  --configuration /etc/connector/config.json
+  --configuration /etc/connector/hardcoded-config.json

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -41,7 +41,7 @@ then
   DENO_PARAMS="--watch --no-clear-screen"
   echo '{"functions": "/functions/src/index.ts", "vendor": "/functions/vendor", "preVendor": true, "schemaMode": "INFER" }' \
     > /etc/connector/config.json
-    
+
 else
   DENO_PARAMS="--import-map ./vendor/import_map.json"
   echo '{"functions": "/functions/src/index.ts", "vendor": "/functions/vendor", "preVendor": false, "schemaMode": "READ", "schemaLocation": "/functions/schema.json"}' \

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -38,19 +38,19 @@ fi
 
 if [[ "$WATCH" == "1" || "$WATCH" == "true" ]]
 then
-  WATCH_PARAM="--watch"
+  DENO_PARAMS="--watch --no-clear-screen"
   echo '{"functions": "/functions/src/index.ts", "vendor": "/functions/vendor", "preVendor": true, "schemaMode": "INFER" }' \
     > /etc/connector/config.json
+    
 else
-  WATCH_PARAM=""
+  DENO_PARAMS="--import-map ./vendor/import_map.json"
   echo '{"functions": "/functions/src/index.ts", "vendor": "/functions/vendor", "preVendor": false, "schemaMode": "READ", "schemaLocation": "/functions/schema.json"}' \
     > /etc/connector/config.json
 fi
 
 deno run \
   --allow-run --allow-net --allow-read --allow-write --allow-env --allow-sys \
-  $WATCH_PARAM \
-  --import-map ./vendor/import_map.json \
+  $DENO_PARAMS \
   /app/mod.ts serve \
   --port 8080 \
   --configuration /etc/connector/config.json

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -2,7 +2,7 @@
 
 ####
 # This script serves as the entrypoint for the Dockerfile
-# It is used both during the build phase (with EARLY_ENTRYPOINT_EXIT=true), and during the run phase.
+# It is used both during the build phase (with PRECACHE_ONLY=true), and during the run phase.
 # This could be split into two scripts easily enough if that is required.
 ####
 
@@ -44,12 +44,12 @@ if [[ "$WATCH" == "1" || "$WATCH" == "true" ]]
 then
   DENO_PARAMS="--watch --no-clear-screen"
   echo '{"functions": "/functions/src/index.ts", "vendor": "/functions/vendor", "preVendor": true, "schemaMode": "INFER" }' \
-    > /etc/connector/hardcoded-config.json
+    > /etc/connector-config.json
 
 else
   DENO_PARAMS=""
   echo '{"functions": "/functions/src/index.ts", "vendor": "/functions/vendor", "preVendor": false, "schemaMode": "READ", "schemaLocation": "/functions/schema.json"}' \
-    > /etc/connector/hardcoded-config.json
+    > /etc/connector-config.json
 fi
 
 deno run \
@@ -57,4 +57,4 @@ deno run \
   $DENO_PARAMS \
   /app/mod.ts serve \
   --port 8080 \
-  --configuration /etc/connector/hardcoded-config.json
+  --configuration /etc/connector-config.json

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -11,7 +11,7 @@
 import ts, { FunctionDeclaration, StringLiteralLike } from "npm:typescript@5.1.6";
 import { resolve, dirname } from "https://deno.land/std@0.203.0/path/mod.ts";
 import { existsSync } from "https://deno.land/std@0.201.0/fs/mod.ts";
-import * as sdk from 'npm:@hasura/ndc-sdk-typescript@1.0.0';
+import * as sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.4';
 
 export type Struct<X> = Record<string, X>;
 
@@ -50,7 +50,6 @@ const scalar_mappings: {[key: string]: string} = {
 const no_ops: sdk.ScalarType = {
   aggregate_functions: {},
   comparison_operators: {},
-  update_operators: {},
 };
 
 // TODO: https://github.com/hasura/ndc-typescript-deno/issues/21 Use standard logging from SDK
@@ -308,14 +307,14 @@ function get_object_type_info(root_file: string, checker: ts.TypeChecker, ty: an
 
 /**
  * This wraps the exception variant programInfoException and calls Deno.exit(1) on error.
- * @param filename_arg 
- * @param vendor_arg 
+ * @param filename 
+ * @param vendorPath 
  * @param perform_vendor 
  * @returns 
  */
-export function programInfo(filename_arg?: string, vendor_arg?: string, perform_vendor?: boolean): ProgramInfo {
+export function programInfo(filename: string, vendorPath: string, perform_vendor: boolean): ProgramInfo {
   try {
-    const info = programInfoException(filename_arg, vendor_arg, perform_vendor);
+    const info = programInfoException(filename, vendorPath, perform_vendor);
     listing('Functions', info.positions, info.schema.functions)
     listing('Procedures', info.positions, info.schema.procedures)
     return info;
@@ -326,10 +325,8 @@ export function programInfo(filename_arg?: string, vendor_arg?: string, perform_
   }
 }
 
-export function programInfoException(filename_arg?: string, vendor_arg?: string, perform_vendor?: boolean): ProgramInfo {
+export function programInfoException(filename: string, vendorPath: string, perform_vendor: boolean): ProgramInfo {
   // TODO: https://github.com/hasura/ndc-typescript-deno/issues/27 This should have already been established upstream
-  const filename = resolve(filename_arg || './functions/index.ts');
-  const vendorPath = resolve(vendor_arg || './vendor');
   const importMapPath = `${vendorPath}/import_map.json`;
   let pathsMap: {[key: string]: Array<string>} = {};
 

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -11,7 +11,7 @@
 import ts, { FunctionDeclaration, StringLiteralLike } from "npm:typescript@5.1.6";
 import { resolve, dirname } from "https://deno.land/std@0.208.0/path/mod.ts";
 import { existsSync } from "https://deno.land/std@0.208.0/fs/mod.ts";
-import * as sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.4';
+import * as sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.5';
 
 export type Struct<X> = Record<string, X>;
 

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -305,21 +305,7 @@ function get_object_type_info(root_file: string, checker: ts.TypeChecker, ty: an
   return null;
 }
 
-/**
- * This wraps the exception variant programInfoException and prints listing for the inference results
- * @param filename
- * @param vendorPath
- * @param perform_vendor
- * @returns
- */
 export function programInfo(filename: string, vendorPath: string, perform_vendor: boolean): ProgramInfo {
-  const info = programInfoException(filename, vendorPath, perform_vendor);
-  listing('Functions', info.positions, info.schema.functions)
-  listing('Procedures', info.positions, info.schema.procedures)
-  return info;
-}
-
-export function programInfoException(filename: string, vendorPath: string, perform_vendor: boolean): ProgramInfo {
   // TODO: https://github.com/hasura/ndc-typescript-deno/issues/27 This should have already been established upstream
   const importMapPath = `${vendorPath}/import_map.json`;
   let pathsMap: {[key: string]: Array<string>} = {};
@@ -548,6 +534,9 @@ export function programInfoException(filename: string, vendorPath: string, perfo
     schema: schema_response,
     positions
   }
+
+  listing('Functions', result.positions, result.schema.functions)
+  listing('Procedures', result.positions, result.schema.procedures)
 
   return result;
 }

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -2,10 +2,10 @@
 /**
  * This module provides the inference implementation for the connector.
  * It relies on the Typescript compiler to perform the heavy lifting.
- * 
+ *
  * The exported function that is intended for use is `programInfo`.
- * 
- * Dependencies are required to be vendored before invocation. 
+ *
+ * Dependencies are required to be vendored before invocation.
  */
 
 import ts, { FunctionDeclaration, StringLiteralLike } from "npm:typescript@5.1.6";
@@ -137,7 +137,7 @@ function validate_type(root_file: string, checker: ts.TypeChecker, object_names:
   const info = get_object_type_info(root_file, checker, ty, name);
   if (info) {
     const type_str_qualified = info.type_name; // lookup_type_name(root_file, checker, info, object_names, name, ty);
-    
+
     // Shortcut recursion if the type has already been named
     if(schema_response.object_types[type_str_qualified]) {
       return { type: 'named', name: type_str_qualified };
@@ -178,7 +178,7 @@ function validate_type(root_file: string, checker: ts.TypeChecker, object_names:
 
 /**
  * Executes `deno vendor` in a subprocess as a conveneience.
- * 
+ *
  * @param vendorPath
  * @param filename
  */
@@ -207,10 +207,10 @@ function error(message: string): never {
 
 /**
  * Logs simple listing of functions/procedures on stderr.
- * 
- * @param prompt 
- * @param positions 
- * @param info 
+ *
+ * @param prompt
+ * @param positions
+ * @param info
  */
 function listing(prompt: string, positions: FunctionPositions, info: Array<sdk.FunctionInfo>) {
   if(info.length > 0) {
@@ -262,7 +262,7 @@ function get_object_type_info(root_file: string, checker: ts.TypeChecker, ty: an
   // - type Bar = { test: string }
   // - type GenericBar<T> = { data: T }
   if ((ty.objectFlags & ts.ObjectFlags.Anonymous) !== 0) {
-    const members = 
+    const members =
       ty.aliasTypeArguments !== undefined
         ? ty.target.members
         : ty.members;
@@ -280,7 +280,7 @@ function get_object_type_info(root_file: string, checker: ts.TypeChecker, ty: an
       generic_parameter_types: [],
       members: get_members(checker, ty, Array.from(ty.members.keys())),
     }
-  } 
+  }
   // Generic interface type - this covers:
   // interface IGenericThing<T> { data: T }
   else if ((ty.objectFlags & ts.ObjectFlags.Reference) !== 0 && (ty.target.objectFlags & ts.ObjectFlags.Interface) !== 0 && checker.isArrayType(ty) == false && ty.symbol.escapedName !== "Promise") {
@@ -307,10 +307,10 @@ function get_object_type_info(root_file: string, checker: ts.TypeChecker, ty: an
 
 /**
  * This wraps the exception variant programInfoException and calls Deno.exit(1) on error.
- * @param filename 
- * @param vendorPath 
- * @param perform_vendor 
- * @returns 
+ * @param filename
+ * @param vendorPath
+ * @param perform_vendor
+ * @returns
  */
 export function programInfo(filename: string, vendorPath: string, perform_vendor: boolean): ProgramInfo {
   try {

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -9,8 +9,8 @@
  */
 
 import ts, { FunctionDeclaration, StringLiteralLike } from "npm:typescript@5.1.6";
-import { resolve, dirname } from "https://deno.land/std@0.203.0/path/mod.ts";
-import { existsSync } from "https://deno.land/std@0.201.0/fs/mod.ts";
+import { resolve, dirname } from "https://deno.land/std@0.208.0/path/mod.ts";
+import { existsSync } from "https://deno.land/std@0.208.0/fs/mod.ts";
 import * as sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.4';
 
 export type Struct<X> = Record<string, X>;

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -306,23 +306,17 @@ function get_object_type_info(root_file: string, checker: ts.TypeChecker, ty: an
 }
 
 /**
- * This wraps the exception variant programInfoException and calls Deno.exit(1) on error.
+ * This wraps the exception variant programInfoException and prints listing for the inference results
  * @param filename
  * @param vendorPath
  * @param perform_vendor
  * @returns
  */
 export function programInfo(filename: string, vendorPath: string, perform_vendor: boolean): ProgramInfo {
-  try {
-    const info = programInfoException(filename, vendorPath, perform_vendor);
-    listing('Functions', info.positions, info.schema.functions)
-    listing('Procedures', info.positions, info.schema.procedures)
-    return info;
-  } catch(e) {
-    console.error(e.message);
-    // console.error(e.stack);
-    Deno.exit(1);
-  }
+  const info = programInfoException(filename, vendorPath, perform_vendor);
+  listing('Functions', info.positions, info.schema.functions)
+  listing('Procedures', info.positions, info.schema.procedures)
+  return info;
 }
 
 export function programInfoException(filename: string, vendorPath: string, perform_vendor: boolean): ProgramInfo {

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,5 +1,3 @@
-
-
 /**
  * Typescript entrypoint for running the connector.
  */
@@ -11,7 +9,7 @@ import { connector } from './connector.ts'
 import sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.4';
 
 const inferCommand = new commander.Command("infer")
-  .argument('<path>', 'Typescript source entrypoint')
+  .argument('<path>', 'TypeScript source entrypoint')
   .option('-v, --vendor <path>', 'Vendor location (optional)')
   .action((entrypoint, cmdObj, _command) => {
     const output = programInfo(entrypoint, cmdObj.vendor, cmdObj.preVendor);

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -6,7 +6,7 @@
 import * as commander  from 'npm:commander@11.0.0';
 import { programInfo } from './infer.ts'
 import { connector } from './connector.ts'
-import sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.4';
+import sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.5';
 
 const inferCommand = new commander.Command("infer")
   .argument('<path>', 'TypeScript source entrypoint')

--- a/src/test/classes_test.ts
+++ b/src/test/classes_test.ts
@@ -1,6 +1,6 @@
 
-import * as test    from "https://deno.land/std@0.202.0/assert/mod.ts";
-import * as path    from "https://deno.land/std@0.203.0/path/mod.ts";
+import * as test    from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as path    from "https://deno.land/std@0.208.0/path/mod.ts";
 import * as infer   from '../infer.ts';
 
 // Classes are currently not supoported and should throw an error

--- a/src/test/complex_dependency_test.ts
+++ b/src/test/complex_dependency_test.ts
@@ -1,6 +1,6 @@
 
-import * as test    from "https://deno.land/std@0.202.0/assert/mod.ts";
-import * as path    from "https://deno.land/std@0.203.0/path/mod.ts";
+import * as test    from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as path    from "https://deno.land/std@0.208.0/path/mod.ts";
 import * as infer   from '../infer.ts';
 
 // This program omits its return type and it is inferred via the 'fetch' dependency.

--- a/src/test/conflicting_names_test.ts
+++ b/src/test/conflicting_names_test.ts
@@ -1,6 +1,6 @@
 
-import * as test  from "https://deno.land/std@0.202.0/assert/mod.ts";
-import * as path  from "https://deno.land/std@0.203.0/path/mod.ts";
+import * as test  from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
 import * as infer from '../infer.ts';
 
 Deno.test("Conflicting Type Names in Imports", () => {
@@ -64,17 +64,14 @@ Deno.test("Conflicting Type Names in Imports", () => {
         Boolean: {
           aggregate_functions: {},
           comparison_operators: {},
-          update_operators: {},
         },
         Float: {
           aggregate_functions: {},
           comparison_operators: {},
-          update_operators: {},
         },
         String: {
           aggregate_functions: {},
           comparison_operators: {},
-          update_operators: {},
         },
       }
     }

--- a/src/test/external_dependencies_test.ts
+++ b/src/test/external_dependencies_test.ts
@@ -1,6 +1,6 @@
 
-import * as test    from "https://deno.land/std@0.202.0/assert/mod.ts";
-import * as path    from "https://deno.land/std@0.203.0/path/mod.ts";
+import * as test    from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as path    from "https://deno.land/std@0.208.0/path/mod.ts";
 import * as infer   from '../infer.ts';
 
 // Skipped due to NPM dependency resolution not currently being supported.
@@ -22,7 +22,6 @@ Deno.test({
           String: {
             aggregate_functions: {},
             comparison_operators: {},
-            update_operators: {},
           },
         },
         object_types: {},

--- a/src/test/infer_test.ts
+++ b/src/test/infer_test.ts
@@ -1,6 +1,6 @@
 
-import * as test    from "https://deno.land/std@0.202.0/assert/mod.ts";
-import * as path    from "https://deno.land/std@0.203.0/path/mod.ts";
+import * as test    from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as path    from "https://deno.land/std@0.208.0/path/mod.ts";
 import * as infer   from '../infer.ts';
 
 Deno.test("Inference", () => {
@@ -21,12 +21,10 @@ Deno.test("Inference", () => {
         Float: {
           aggregate_functions: {},
           comparison_operators: {},
-          update_operators: {},
         },
         String: {
           aggregate_functions: {},
           comparison_operators: {},
-          update_operators: {},
         },
       },
       object_types: {},
@@ -143,12 +141,10 @@ Deno.test("Complex Inference", () => {
         Float: {
           aggregate_functions: {},
           comparison_operators: {},
-          update_operators: {},
         },
         String: {
           aggregate_functions: {},
           comparison_operators: {},
-          update_operators: {},
         },
       }
     }

--- a/src/test/inline_types_test.ts
+++ b/src/test/inline_types_test.ts
@@ -1,6 +1,6 @@
 
-import * as test    from "https://deno.land/std@0.202.0/assert/mod.ts";
-import * as path    from "https://deno.land/std@0.203.0/path/mod.ts";
+import * as test    from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as path    from "https://deno.land/std@0.208.0/path/mod.ts";
 import * as infer   from '../infer.ts';
 
 Deno.test({ name: "Type Parameters",
@@ -20,12 +20,10 @@ Deno.test({ name: "Type Parameters",
           "String": {
             "aggregate_functions": {},
             "comparison_operators": {},
-            "update_operators": {}
           },
           "Float": {
             "aggregate_functions": {},
             "comparison_operators": {},
-            "update_operators": {}
           }
         },
         "object_types": {

--- a/src/test/pg_dep_test.ts
+++ b/src/test/pg_dep_test.ts
@@ -1,6 +1,6 @@
 
-import * as test    from "https://deno.land/std@0.202.0/assert/mod.ts";
-import * as path    from "https://deno.land/std@0.203.0/path/mod.ts";
+import * as test    from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as path    from "https://deno.land/std@0.208.0/path/mod.ts";
 import * as infer   from '../infer.ts';
 
 // NOTE: It would be good to have explicit timeout for this
@@ -84,17 +84,14 @@ Deno.test("Inferred Dependency Based Result Type", () => {
         String: {
           aggregate_functions: {},
           comparison_operators: {},
-          update_operators: {},
         },
         insert_todos_output: {
           aggregate_functions: {},
           comparison_operators: {},
-          update_operators: {},
         },
         insert_user_output: {
           aggregate_functions: {},
           comparison_operators: {},
-          update_operators: {},
         },
       },
       object_types: {},

--- a/src/test/recursive_types_test.ts
+++ b/src/test/recursive_types_test.ts
@@ -1,6 +1,6 @@
 
-import * as test  from "https://deno.land/std@0.202.0/assert/mod.ts";
-import * as path  from "https://deno.land/std@0.203.0/path/mod.ts";
+import * as test  from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
 import * as infer from '../infer.ts';
 
 Deno.test("Recursive Types", () => {
@@ -51,7 +51,6 @@ Deno.test("Recursive Types", () => {
         Float: {
           aggregate_functions: {},
           comparison_operators: {},
-          update_operators: {},
         },
       },
     }

--- a/src/test/type_parameters_test.ts
+++ b/src/test/type_parameters_test.ts
@@ -1,6 +1,6 @@
 
-import * as test    from "https://deno.land/std@0.202.0/assert/mod.ts";
-import * as path    from "https://deno.land/std@0.203.0/path/mod.ts";
+import * as test    from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as path    from "https://deno.land/std@0.208.0/path/mod.ts";
 import * as infer   from '../infer.ts';
 
 Deno.test({ name: "Type Parameters",
@@ -58,12 +58,10 @@ Deno.test({ name: "Type Parameters",
         Float: {
           aggregate_functions: {},
           comparison_operators: {},
-          update_operators: {},
         },
         String: {
           aggregate_functions: {},
           comparison_operators: {},
-          update_operators: {},
         },
       },
       procedures: [

--- a/src/test/validation_algorithm_test.ts
+++ b/src/test/validation_algorithm_test.ts
@@ -1,6 +1,6 @@
 
-import * as test    from "https://deno.land/std@0.202.0/assert/mod.ts";
-import * as path    from "https://deno.land/std@0.203.0/path/mod.ts";
+import * as test    from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as path    from "https://deno.land/std@0.208.0/path/mod.ts";
 import * as infer   from '../infer.ts';
 
 Deno.test({ name: "Type Parameters",
@@ -234,12 +234,10 @@ Deno.test({ name: "Type Parameters",
         Float: {
           aggregate_functions: {},
           comparison_operators: {},
-          update_operators: {},
         },
         String: {
           aggregate_functions: {},
           comparison_operators: {},
-          update_operators: {},
         },
       }
     }

--- a/src/test/void_test.ts
+++ b/src/test/void_test.ts
@@ -1,6 +1,6 @@
 
-import * as test    from "https://deno.land/std@0.202.0/assert/mod.ts";
-import * as path    from "https://deno.land/std@0.203.0/path/mod.ts";
+import * as test    from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as path    from "https://deno.land/std@0.208.0/path/mod.ts";
 import * as infer   from '../infer.ts';
 
 // NOTE: It would be good to have explicit timeout for this


### PR DESCRIPTION
## Description
This PR improves support for running the connector using `deno run --watch` where the connector gets restarted by Deno whenever the function files change. It adds support for running the connector in watch mode using Docker.

```bash
docker build . -t "typescript-deno:latest" # only because we don't publish a docker container anywhere
docker run -it --rm -p 8080:8080 -e WATCH=1 -v ./functions:/functions/src typescript-deno:latest
```

Part of the improvements to make watch mode work better include
* rearranging when we infer the functions schema to reduce work done, but also reduce watch-induced reloads caused by vendoring during inference
* rearranging the dockerfile and entrypoint script so that the generated vendor, node_modules and schema.json artifacts are stored outside of the functions source directory, so that we don't pollute the user's volume mount

Various version updates have also been made:
* Version of deno used in Docker has been updated
* Deno github action has been updated
* the deno std library version has been updated and made consistent across the entire project

## Solution Design
We now have a difference between `RawConfiguration` and `Configuration`. We perform our inference only in `validate_raw_configuration` and capture the results in the `Configuration`. This then powers every usage of the inference, including the schema endpoint and actual queries. It also provides a central place for configuration defaulting (such as defaulting to "INFER").

The entrypoint script now looks for a `WATCH` env var and if it is `"1"` or `"true"` it generates a different configuration that enables INFER mode and turns on deno's `--watch` flag.