### PR TITLE
Support for Nullable Types

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,18 @@ This changelog documents the changes between release versions.
 
 Changes to be included in the next upcoming release.
 
+Support for "nullable" types, for example `string | null`, `string | undefined`, `string | null | undefined`,
+and optional object properties.
+
+PR: https://github.com/hasura/ndc-typescript-deno/pull/82
+
 ## v0.20
 
 Improved support for running the connector in Watch mode, where it will auto-restart when changes
 to the functions are made.
 
 * The Docker container is now compatible with watch mode and can be used for local development
-* README documentation about watch mode updated to indicate the need to explicitly watch the functions 
+* README documentation about watch mode updated to indicate the need to explicitly watch the functions
   folder (ie `--watch=./functions`)
 * `functions` configuration property is now required
 * Type inference is now only done at connector startup, not every time the `/schema` endpoint is called

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -3,15 +3,21 @@
  * Using https://github.com/hasura/ndc-qdrant/blob/main/src/index.ts as an example.
  */
 
-import { FunctionPositions, ProgramInfo, programInfo, Struct } from "./infer.ts";
+import { FunctionDefinitions, get_ndc_schema, NullOrUndefinability, ObjectTypeDefinitions, ProgramSchema, inferProgramSchema, Struct, TypeDefinition } from "./infer.ts";
 import { resolve } from "https://deno.land/std@0.208.0/path/mod.ts";
 import { JSONSchemaObject } from "npm:@json-schema-tools/meta-schema";
+import { isArray, unreachable } from "./util.ts";
 
 import * as sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.5';
 export * as sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.5';
 
 export type State = {
-  functions: any
+  functions: RuntimeFunctions
+}
+
+export type RuntimeFunctions = {
+  // deno-lint-ignore ban-types
+  [function_name: string]: Function
 }
 
 export interface RawConfiguration {
@@ -56,7 +62,7 @@ export const RAW_CONFIGURATION_SCHEMA: JSONSchemaObject = {
 
 type Configuration = {
   inferenceConfig: InferenceConfig,
-  programInfo: ProgramInfo,
+  programSchema: ProgramSchema,
 }
 
 type InferenceConfig = {
@@ -75,9 +81,9 @@ export const CAPABILITIES_RESPONSE: sdk.CapabilitiesResponse = {
   },
 };
 
-type Payload<X> = {
+type Payload = {
   function: string,
-  args: Struct<X>
+  args: Struct<unknown>
 }
 
 
@@ -91,7 +97,7 @@ type Payload<X> = {
  * @param cmdObj
  * @returns Schema and argument position information
  */
-export function getInfo(cmdObj: InferenceConfig): ProgramInfo {
+export function getProgramSchema(cmdObj: InferenceConfig): ProgramSchema {
   switch(cmdObj.schemaMode) {
     /**
      * The READ option is available in case the user wants to pre-cache their schema during development.
@@ -108,15 +114,15 @@ export function getInfo(cmdObj: InferenceConfig): ProgramInfo {
     }
     case 'INFER': {
       console.error(`Inferring schema with map location ${cmdObj.vendorDir}`);
-      const info = programInfo(cmdObj.functions, cmdObj.vendorDir, cmdObj.preVendor);
+      const programSchema = inferProgramSchema(cmdObj.functions, cmdObj.vendorDir, cmdObj.preVendor);
       const schemaLocation = cmdObj.schemaLocation;
       if(schemaLocation) {
         console.error(`Writing schema to ${cmdObj.schemaLocation}`);
-        const infoString = JSON.stringify(info);
+        const infoString = JSON.stringify(programSchema);
         // NOTE: Using sync functions should be ok since they're run on startup.
         Deno.writeTextFileSync(schemaLocation, infoString);
       }
-      return info;
+      return programSchema;
     }
     default:
       throw new Error('Invalid schema-mode. Use READ or INFER.');
@@ -129,42 +135,89 @@ export function getInfo(cmdObj: InferenceConfig): ProgramInfo {
  * This doesn't catch any exceptions.
  *
  * @param functions
- * @param positions
+ * @param function_definitions
  * @param payload
  * @returns the result of invocation with no wrapper
  */
-async function invoke(functions: any, positions: FunctionPositions, payload: Payload<unknown>): Promise<any> {
-  const ident = payload.function;
-  const func = functions[ident as any] as any;
-  const args = reposition(positions, payload);
+async function invoke(functions: RuntimeFunctions, function_definitions: FunctionDefinitions, object_type_definitions: ObjectTypeDefinitions, payload: Payload): Promise<unknown> {
+  const func = functions[payload.function];
+  const args = prepare_arguments(function_definitions, object_type_definitions, payload);
 
-  let result = func.apply(null, args);
-  if (typeof result === "object" && 'then' in result && typeof result.then === "function") {
-    result = await result;
+  try {
+    let result = func.apply(undefined, args);
+    if (typeof result === "object" && 'then' in result && typeof result.then === "function") {
+      result = await result;
+    }
+    return result;
+  } catch (e) {
+    throw new sdk.InternalServerError(`Error encountered when invoking function ${func}`, { message: e.message, stack: e.stack });
   }
-  return result;
 }
 
 /**
  * This takes argument position information and a payload of function
  * and named arguments and returns the correctly ordered arguments ready to be applied.
  *
- * @param functions
+ * @param function_definitions
  * @param payload
  * @returns An array of the function's arguments in the definition order
  */
-function reposition<X>(functions: FunctionPositions, payload: Payload<X>): Array<X> {
-  const positions = functions[payload.function];
+function prepare_arguments(function_definitions: FunctionDefinitions, object_type_definitions: ObjectTypeDefinitions, payload: Payload): unknown[] {
+  const function_definition = function_definitions[payload.function];
 
-  if(!positions) {
-    throw new Error(`Couldn't find function ${payload.function} in schema.`);
+  if(!function_definition) {
+    throw new sdk.InternalServerError(`Couldn't find function ${payload.function} in schema.`);
   }
 
-  return positions.map(k => payload.args[k]);
+  return function_definition.arguments
+    .map(argDef => coerce_argument_value(payload.args[argDef.argument_name], argDef.type, [argDef.argument_name], object_type_definitions));
+}
+
+function coerce_argument_value(value: unknown, type: TypeDefinition, value_path: string[], object_type_definitions: ObjectTypeDefinitions): unknown {
+  switch (type.type) {
+    case "array":
+      if (!isArray(value))
+        throw new sdk.BadRequest("Unexpected value in function arguments. Expected an array.", { value_path });
+      return value.map((element, index) => coerce_argument_value(element, type.element_type, [...value_path, `[${index}]`], object_type_definitions))
+
+    case "nullable":
+      if (value === null) {
+        return type.null_or_undefinability == NullOrUndefinability.AcceptsUndefinedOnly
+          ? undefined
+          : null;
+      } else if (value === undefined) {
+        return type.null_or_undefinability == NullOrUndefinability.AcceptsNullOnly
+          ? null
+          : undefined;
+      } else {
+        return coerce_argument_value(value, type.underlying_type, value_path, object_type_definitions)
+      }
+    case "named":
+      if (type.kind === "scalar") {
+        // Scalars are currently treated as opaque values, which is a bit dodgy
+        return value;
+      } else {
+        const object_type_definition = object_type_definitions[type.name];
+        if (!object_type_definition)
+          throw new sdk.InternalServerError(`Couldn't find object type ${type.name} in the schema`);
+        if (value === null || typeof value !== "object") {
+          throw new sdk.BadRequest(`Unexpected value in function arguments. Expected an object.`, { value_path });
+        }
+        return Object.fromEntries(Object.entries(value).map(([prop_name, prop_value]) => {
+          const property_definition = object_type_definition.properties.find(def => def.property_name === prop_name);
+          if (!property_definition)
+            throw new sdk.BadRequest(`Unexpected property '${prop_name}' on object in function arguments.`, { value_path });
+
+          return [prop_name, coerce_argument_value(prop_value, property_definition.type, [...value_path, prop_name], object_type_definitions)]
+        }));
+      }
+    default:
+      return unreachable(type["type"]);
+  }
 }
 
 // TODO: https://github.com/hasura/ndc-typescript-deno/issues/26 Do deeper field recursion once that's available
-function pruneFields<X>(func: string, fields: Struct<sdk.Field> | null | undefined, result: Struct<X>): Struct<X> {
+function pruneFields(func: string, fields: Struct<sdk.Field> | null | undefined, result: unknown): unknown {
   // This seems like a bug to request {} fields when expecting a scalar response...
   // File with engine?
   if(!fields || Object.keys(fields).length == 0) {
@@ -173,12 +226,16 @@ function pruneFields<X>(func: string, fields: Struct<sdk.Field> | null | undefin
     return result;
   }
 
-  const response: Struct<X> = {};
+  const response: Struct<unknown> = {};
+
+  if (result === null || Array.isArray(result) || typeof result !== "object") {
+    throw new sdk.InternalServerError(`Function '${func}' did not return an object when expected to`);
+  }
 
   for(const [k,v] of Object.entries(fields)) {
     switch(v.type) {
       case 'column':
-        response[k] = result[v.column];
+        response[k] = (result as Record<string, unknown>)[v.column] ?? null; // Coalesce undefined into null to ensure we always have a value for a requested column
         break;
       default:
         console.error(`Function ${func} field of type ${v.type} is not supported.`);
@@ -194,18 +251,13 @@ async function query(
   func: string,
   requestArgs: Struct<unknown>,
   requestFields?: { [k: string]: sdk.Field; } | null | undefined
-): Promise<Struct<unknown>> {
-  const payload: Payload<unknown> = {
+): Promise<unknown> {
+  const payload: Payload = {
     function: func,
     args: requestArgs
   };
-  try {
-    const result = await invoke(state.functions, configuration.programInfo.positions, payload);
-    const pruned = pruneFields(func, requestFields, result);
-    return pruned;
-  } catch(e) {
-    throw new sdk.InternalServerError(`Error encountered when invoking function ${func}`, { message: e.message, stack: e.stack });
-  }
+  const result = await invoke(state.functions, configuration.programSchema.functions, configuration.programSchema.object_types, payload);
+  return pruneFields(func, requestFields, result);
 }
 
 function resolveArguments(
@@ -274,15 +326,15 @@ export const connector: sdk.Connector<RawConfiguration, Configuration, State> = 
       schemaLocation: configuration.schemaLocation,
       vendorDir: resolve(configuration.vendor || "./vendor"),
     };
-    const programInfo = getInfo(inferenceConfig);
+    const programSchema = getProgramSchema(inferenceConfig);
     return Promise.resolve({
       inferenceConfig,
-      programInfo
+      programSchema
     });
   },
 
   get_schema(config: Configuration): Promise<sdk.SchemaResponse> {
-    return Promise.resolve(config.programInfo.schema);
+    return Promise.resolve(get_ndc_schema(config.programSchema));
   },
 
   // TODO: https://github.com/hasura/ndc-typescript-deno/issues/28 What do we want explain to do in this scenario?

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -3,7 +3,8 @@
  * Using https://github.com/hasura/ndc-qdrant/blob/main/src/index.ts as an example.
  */
 
-import { FunctionDefinitions, get_ndc_schema, NullOrUndefinability, ObjectTypeDefinitions, ProgramSchema, inferProgramSchema, Struct, TypeDefinition } from "./infer.ts";
+import { FunctionDefinitions, get_ndc_schema, NullOrUndefinability, ObjectTypeDefinitions, ProgramSchema, TypeDefinition } from "./schema.ts";
+import { inferProgramSchema, Struct, } from "./infer.ts";
 import { resolve } from "https://deno.land/std@0.208.0/path/mod.ts";
 import { JSONSchemaObject } from "npm:@json-schema-tools/meta-schema";
 import { isArray, unreachable } from "./util.ts";

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -11,140 +11,10 @@
 import ts, { FunctionDeclaration, StringLiteralLike } from "npm:typescript@5.1.6";
 import { resolve, dirname } from "https://deno.land/std@0.208.0/path/mod.ts";
 import { existsSync } from "https://deno.land/std@0.208.0/fs/mod.ts";
-import * as sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.5';
-import { mapObject, mapObjectValues, unreachable } from "./util.ts";
+import { mapObject } from "./util.ts";
+import { FunctionDefinitions, FunctionNdcKind, NullOrUndefinability, ObjectTypeDefinitions, ProgramSchema, ScalarTypeDefinitions, TypeDefinition, listing } from "./schema.ts";
 
 export type Struct<X> = Record<string, X>;
-
-export type ProgramSchema = {
-  functions: FunctionDefinitions
-  object_types: ObjectTypeDefinitions
-  scalar_types: ScalarTypeDefinitions
-}
-
-export type FunctionDefinitions = {
-  [function_name: string]: FunctionDefinition
-}
-
-export type FunctionDefinition = {
-  ndc_kind: FunctionNdcKind
-  description: string | null,
-  arguments: ArgumentDefinition[] // Function arguments are ordered
-  result_type: TypeDefinition
-}
-
-export enum FunctionNdcKind {
-  Function = "Function",
-  Procedure = "Procedure"
-}
-
-export type ArgumentDefinition = {
-  argument_name: string,
-  description: string | null,
-  type: TypeDefinition
-}
-
-export type ObjectTypeDefinitions = {
-  [object_type_name: string]: ObjectTypeDefinition
-}
-
-export type ObjectTypeDefinition = {
-  properties: ObjectPropertyDefinition[]
-}
-
-export type ObjectPropertyDefinition = {
-  property_name: string,
-  type: TypeDefinition,
-}
-
-export type ScalarTypeDefinitions = {
-  [scalar_type_name: string]: ScalarTypeDefinition
-}
-
-export type ScalarTypeDefinition = Record<string, never> // Empty object, for now
-
-export type TypeDefinition = ArrayTypeDefinition | NullableTypeDefinition | NamedTypeDefinition
-
-export type ArrayTypeDefinition = {
-  type: "array"
-  element_type: TypeDefinition
-}
-
-export type NullableTypeDefinition = {
-  type: "nullable",
-  null_or_undefinability: NullOrUndefinability
-  underlying_type: TypeDefinition
-}
-
-export type NamedTypeDefinition = {
-  type: "named"
-  name: string
-  kind: "scalar" | "object"
-}
-
-export enum NullOrUndefinability {
-  AcceptsNullOnly = "AcceptsNullOnly",
-  AcceptsUndefinedOnly = "AcceptsUndefinedOnly",
-  AcceptsEither = "AcceptsEither",
-}
-
-export function get_ndc_schema(programInfo: ProgramSchema): sdk.SchemaResponse {
-  const functions = Object.entries(programInfo.functions);
-
-  const object_types = mapObjectValues(programInfo.object_types, obj_def => {
-    return {
-      fields: Object.fromEntries(obj_def.properties.map(prop_def => [prop_def.property_name, { type: convert_type_definition_to_sdk_type(prop_def.type)}]))
-    }
-  });
-
-  const scalar_types = mapObjectValues(programInfo.scalar_types, _scalar_def => {
-    return {
-      aggregate_functions: {},
-      comparison_operators: {},
-    }
-  })
-
-  return {
-    functions: functions
-      .filter(([_, def]) => def.ndc_kind === FunctionNdcKind.Function)
-      .map(([name, def]) => convert_function_definition_to_sdk_schema_type(name, def)),
-    procedures: functions
-      .filter(([_, def]) => def.ndc_kind === FunctionNdcKind.Procedure)
-      .map(([name, def]) => convert_function_definition_to_sdk_schema_type(name, def)),
-    collections: [],
-    object_types,
-    scalar_types,
-  }
-}
-
-function convert_type_definition_to_sdk_type(typeDef: TypeDefinition): sdk.Type {
-  switch (typeDef.type) {
-    case "array": return { type: "array", element_type: convert_type_definition_to_sdk_type(typeDef.element_type) }
-    case "nullable": return { type: "nullable", underlying_type: convert_type_definition_to_sdk_type(typeDef.underlying_type) }
-    case "named": return { type: "named", name: typeDef.name }
-    default: return unreachable(typeDef["type"])
-  }
-}
-
-function convert_function_definition_to_sdk_schema_type(function_name: string, definition: FunctionDefinition): sdk.FunctionInfo | sdk.ProcedureInfo {
-  const args =
-    definition.arguments
-      .map(arg_def =>
-        [ arg_def.argument_name,
-          {
-            type: convert_type_definition_to_sdk_type(arg_def.type),
-            ...(arg_def.description ? { description: arg_def.description } : {}),
-          }
-        ]
-      );
-
-  return {
-    name: function_name,
-    arguments: Object.fromEntries(args),
-    result_type: convert_type_definition_to_sdk_type(definition.result_type),
-    ...(definition.description ? { description: definition.description } : {}),
-  }
-}
 
 const scalar_mappings: {[key: string]: string} = {
   "string": "String",
@@ -306,26 +176,6 @@ function pre_vendor(vendorPath: string, filename: string) {
 
 function throw_error(message: string): never {
   throw new Error(message);
-}
-
-/**
- * Logs simple listing of functions/procedures on stderr.
- *
- * @param prompt
- * @param functionDefinitions
- * @param info
- */
-function listing(functionNdcKind: FunctionNdcKind, functionDefinitions: FunctionDefinitions) {
-  const functions = Object.entries(functionDefinitions).filter(([_, def]) => def.ndc_kind === functionNdcKind);
-  if (functions.length > 0) {
-    console.error(``);
-    console.error(`${functionNdcKind}s:`)
-    for (const [function_name, function_definition] of functions) {
-      const args = function_definition.arguments.join(', ');
-      console.error(`* ${function_name}(${args})`);
-    }
-    console.error(``);
-  }
 }
 
 /**

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -132,8 +132,8 @@ function convert_function_definition_to_sdk_schema_type(function_name: string, d
       .map(arg_def =>
         [ arg_def.argument_name,
           {
-            description: definition.description ?? undefined,
-            type: convert_type_definition_to_sdk_type(arg_def.type)
+            type: convert_type_definition_to_sdk_type(arg_def.type),
+            ...(arg_def.description ? { description: arg_def.description } : {}),
           }
         ]
       );
@@ -142,7 +142,7 @@ function convert_function_definition_to_sdk_schema_type(function_name: string, d
     name: function_name,
     arguments: Object.fromEntries(args),
     result_type: convert_type_definition_to_sdk_type(definition.result_type),
-    description: definition.description ?? undefined,
+    ...(definition.description ? { description: definition.description } : {}),
   }
 }
 

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -4,7 +4,7 @@
 
 // NOTE: Ensure that sdk matches version in connector.ts
 import * as commander  from 'npm:commander@11.0.0';
-import { programInfo } from './infer.ts'
+import { inferProgramSchema } from './infer.ts'
 import { connector } from './connector.ts'
 import sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.5';
 
@@ -12,7 +12,7 @@ const inferCommand = new commander.Command("infer")
   .argument('<path>', 'TypeScript source entrypoint')
   .option('-v, --vendor <path>', 'Vendor location (optional)')
   .action((entrypoint, cmdObj, _command) => {
-    const output = programInfo(entrypoint, cmdObj.vendor, cmdObj.preVendor);
+    const output = inferProgramSchema(entrypoint, cmdObj.vendor, cmdObj.preVendor);
     console.log(JSON.stringify(output));
   });
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,0 +1,152 @@
+import * as sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.5';
+import { mapObjectValues, unreachable } from "./util.ts";
+
+export type ProgramSchema = {
+  functions: FunctionDefinitions
+  object_types: ObjectTypeDefinitions
+  scalar_types: ScalarTypeDefinitions
+}
+
+export type FunctionDefinitions = {
+  [function_name: string]: FunctionDefinition
+}
+
+export type FunctionDefinition = {
+  ndc_kind: FunctionNdcKind
+  description: string | null,
+  arguments: ArgumentDefinition[] // Function arguments are ordered
+  result_type: TypeDefinition
+}
+
+export enum FunctionNdcKind {
+  Function = "Function",
+  Procedure = "Procedure"
+}
+
+export type ArgumentDefinition = {
+  argument_name: string,
+  description: string | null,
+  type: TypeDefinition
+}
+
+export type ObjectTypeDefinitions = {
+  [object_type_name: string]: ObjectTypeDefinition
+}
+
+export type ObjectTypeDefinition = {
+  properties: ObjectPropertyDefinition[]
+}
+
+export type ObjectPropertyDefinition = {
+  property_name: string,
+  type: TypeDefinition,
+}
+
+export type ScalarTypeDefinitions = {
+  [scalar_type_name: string]: ScalarTypeDefinition
+}
+
+export type ScalarTypeDefinition = Record<string, never> // Empty object, for now
+
+export type TypeDefinition = ArrayTypeDefinition | NullableTypeDefinition | NamedTypeDefinition
+
+export type ArrayTypeDefinition = {
+  type: "array"
+  element_type: TypeDefinition
+}
+
+export type NullableTypeDefinition = {
+  type: "nullable",
+  null_or_undefinability: NullOrUndefinability
+  underlying_type: TypeDefinition
+}
+
+export type NamedTypeDefinition = {
+  type: "named"
+  name: string
+  kind: "scalar" | "object"
+}
+
+export enum NullOrUndefinability {
+  AcceptsNullOnly = "AcceptsNullOnly",
+  AcceptsUndefinedOnly = "AcceptsUndefinedOnly",
+  AcceptsEither = "AcceptsEither",
+}
+
+export function get_ndc_schema(programInfo: ProgramSchema): sdk.SchemaResponse {
+  const functions = Object.entries(programInfo.functions);
+
+  const object_types = mapObjectValues(programInfo.object_types, obj_def => {
+    return {
+      fields: Object.fromEntries(obj_def.properties.map(prop_def => [prop_def.property_name, { type: convert_type_definition_to_sdk_type(prop_def.type)}]))
+    }
+  });
+
+  const scalar_types = mapObjectValues(programInfo.scalar_types, _scalar_def => {
+    return {
+      aggregate_functions: {},
+      comparison_operators: {},
+    }
+  })
+
+  return {
+    functions: functions
+      .filter(([_, def]) => def.ndc_kind === FunctionNdcKind.Function)
+      .map(([name, def]) => convert_function_definition_to_sdk_schema_type(name, def)),
+    procedures: functions
+      .filter(([_, def]) => def.ndc_kind === FunctionNdcKind.Procedure)
+      .map(([name, def]) => convert_function_definition_to_sdk_schema_type(name, def)),
+    collections: [],
+    object_types,
+    scalar_types,
+  }
+}
+
+function convert_type_definition_to_sdk_type(typeDef: TypeDefinition): sdk.Type {
+  switch (typeDef.type) {
+    case "array": return { type: "array", element_type: convert_type_definition_to_sdk_type(typeDef.element_type) }
+    case "nullable": return { type: "nullable", underlying_type: convert_type_definition_to_sdk_type(typeDef.underlying_type) }
+    case "named": return { type: "named", name: typeDef.name }
+    default: return unreachable(typeDef["type"])
+  }
+}
+
+function convert_function_definition_to_sdk_schema_type(function_name: string, definition: FunctionDefinition): sdk.FunctionInfo | sdk.ProcedureInfo {
+  const args =
+    definition.arguments
+      .map(arg_def =>
+        [ arg_def.argument_name,
+          {
+            type: convert_type_definition_to_sdk_type(arg_def.type),
+            ...(arg_def.description ? { description: arg_def.description } : {}),
+          }
+        ]
+      );
+
+  return {
+    name: function_name,
+    arguments: Object.fromEntries(args),
+    result_type: convert_type_definition_to_sdk_type(definition.result_type),
+    ...(definition.description ? { description: definition.description } : {}),
+  }
+}
+
+/**
+ * Logs simple listing of functions/procedures on stderr.
+ *
+ * @param prompt
+ * @param functionDefinitions
+ * @param info
+ */
+export function listing(functionNdcKind: FunctionNdcKind, functionDefinitions: FunctionDefinitions) {
+  const functions = Object.entries(functionDefinitions).filter(([_, def]) => def.ndc_kind === functionNdcKind);
+  if (functions.length > 0) {
+    console.error(``);
+    console.error(`${functionNdcKind}s:`)
+    for (const [function_name, function_definition] of functions) {
+      const args = function_definition.arguments.join(', ');
+      console.error(`* ${function_name}(${args})`);
+    }
+    console.error(``);
+  }
+}

--- a/src/test/classes_test.ts
+++ b/src/test/classes_test.ts
@@ -1,13 +1,13 @@
 
-import * as test    from "https://deno.land/std@0.208.0/assert/mod.ts";
-import * as path    from "https://deno.land/std@0.208.0/path/mod.ts";
-import * as infer   from '../infer.ts';
+import * as test  from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
+import * as infer from '../infer.ts';
 
 // Classes are currently not supoported and should throw an error
 Deno.test("Complex Dependency", () => {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/classes.ts'));
   const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
   test.assertThrows(() => {
-    infer.programInfo(program_path, vendor_path, false);
+    infer.inferProgramSchema(program_path, vendor_path, false);
   })
 });

--- a/src/test/classes_test.ts
+++ b/src/test/classes_test.ts
@@ -4,7 +4,7 @@ import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
 import * as infer from '../infer.ts';
 
 // Classes are currently not supoported and should throw an error
-Deno.test("Complex Dependency", () => {
+Deno.test("Classes", () => {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/classes.ts'));
   const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
   test.assertThrows(() => {

--- a/src/test/complex_dependency_test.ts
+++ b/src/test/complex_dependency_test.ts
@@ -1,18 +1,19 @@
 
-import * as test    from "https://deno.land/std@0.208.0/assert/mod.ts";
-import * as path    from "https://deno.land/std@0.208.0/path/mod.ts";
-import * as infer   from '../infer.ts';
+import * as test  from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
+import * as infer from '../infer.ts';
 
 // This program omits its return type and it is inferred via the 'fetch' dependency.
 Deno.test("Inference on Dependency", () => {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/infinite_loop.ts'));
   const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
-  const program_results = infer.programInfo(program_path, vendor_path, false);
-  test.assertEquals(program_results.schema.procedures, [
-    {
-      name: "infinite_loop",
-      arguments: {},
-      result_type: { type: "named", name: "Response" }
+  const program_schema = infer.inferProgramSchema(program_path, vendor_path, false);
+  test.assertEquals(program_schema.functions, {
+    infinite_loop: {
+      ndc_kind: infer.FunctionNdcKind.Procedure,
+      description: null,
+      arguments: [],
+      result_type: { type: "named", kind: "object", name: "Response" }
     }
-  ]);
+  });
 });

--- a/src/test/complex_dependency_test.ts
+++ b/src/test/complex_dependency_test.ts
@@ -2,6 +2,7 @@
 import * as test  from "https://deno.land/std@0.208.0/assert/mod.ts";
 import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
 import * as infer from '../infer.ts';
+import { FunctionNdcKind } from "../schema.ts";
 
 // This program omits its return type and it is inferred via the 'fetch' dependency.
 Deno.test("Inference on Dependency", () => {
@@ -10,7 +11,7 @@ Deno.test("Inference on Dependency", () => {
   const program_schema = infer.inferProgramSchema(program_path, vendor_path, false);
   test.assertEquals(program_schema.functions, {
     infinite_loop: {
-      ndc_kind: infer.FunctionNdcKind.Procedure,
+      ndc_kind: FunctionNdcKind.Procedure,
       description: null,
       arguments: [],
       result_type: { type: "named", kind: "object", name: "Response" }

--- a/src/test/conflicting_names_test.ts
+++ b/src/test/conflicting_names_test.ts
@@ -7,73 +7,67 @@ Deno.test("Conflicting Type Names in Imports", () => {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/conflicting_names.ts'));
   const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
 
-  const program_results = infer.programInfo(program_path, vendor_path, false);
+  const program_schema = infer.inferProgramSchema(program_path, vendor_path, false);
 
-  test.assertEquals(program_results, {
-    positions: {
-      foo: [],
-    },
-    schema: {
-      collections: [],
-      functions: [],
-      object_types: {
-        Foo: {
-          fields: {
-            x: {
-              type: {
-                name: "Boolean",
-                type: "named",
-              },
-            },
-            y: {
-              type: {
-                name: "conflicting_names_dep_Foo",
-                type: "named",
-              },
-            },
-          },
-        },
-        conflicting_names_dep_Foo: {
-          fields: {
-            a: {
-              type: {
-                name: "String",
-                type: "named",
-              },
-            },
-            b: {
-              type: {
-                name: "Float",
-                type: "named",
-              },
-            },
-          },
-        },
-      },
-      procedures: [
-        {
-          arguments: {},
-          name: "foo",
-          result_type: {
-            name: "Foo",
-            type: "named",
-          },
-        },
-      ],
-      scalar_types: {
-        Boolean: {
-          aggregate_functions: {},
-          comparison_operators: {},
-        },
-        Float: {
-          aggregate_functions: {},
-          comparison_operators: {},
-        },
-        String: {
-          aggregate_functions: {},
-          comparison_operators: {},
+  test.assertEquals(program_schema, {
+    functions: {
+      "foo": {
+        ndc_kind: infer.FunctionNdcKind.Procedure,
+        description: null,
+        arguments: [],
+        result_type: {
+          name: "Foo",
+          kind: "object",
+          type: "named",
         },
       }
+    },
+    object_types: {
+      Foo: {
+        properties: [
+          {
+            property_name: "x",
+            type: {
+              name: "Boolean",
+              kind: "scalar",
+              type: "named",
+            },
+          },
+          {
+            property_name: "y",
+            type: {
+              name: "conflicting_names_dep_Foo",
+              kind: "object",
+              type: "named",
+            },
+          },
+        ]
+      },
+      conflicting_names_dep_Foo: {
+        properties: [
+          {
+            property_name: "a",
+            type: {
+              name: "String",
+              kind: "scalar",
+              type: "named",
+            },
+          },
+          {
+            property_name: "b",
+            type: {
+              name: "Float",
+              kind: "scalar",
+              type: "named",
+            },
+          },
+        ]
+      },
+    },
+    scalar_types: {
+      Boolean: {},
+      Float: {},
+      String: {},
     }
   })
 });

--- a/src/test/conflicting_names_test.ts
+++ b/src/test/conflicting_names_test.ts
@@ -2,6 +2,7 @@
 import * as test  from "https://deno.land/std@0.208.0/assert/mod.ts";
 import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
 import * as infer from '../infer.ts';
+import { FunctionNdcKind } from "../schema.ts";
 
 Deno.test("Conflicting Type Names in Imports", () => {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/conflicting_names.ts'));
@@ -12,7 +13,7 @@ Deno.test("Conflicting Type Names in Imports", () => {
   test.assertEquals(program_schema, {
     functions: {
       "foo": {
-        ndc_kind: infer.FunctionNdcKind.Procedure,
+        ndc_kind: FunctionNdcKind.Procedure,
         description: null,
         arguments: [],
         result_type: {

--- a/src/test/data/nullable_types.ts
+++ b/src/test/data/nullable_types.ts
@@ -1,0 +1,19 @@
+
+type MyObject = {
+  string: string,
+  nullableString: string | null,
+  optionalString?: string
+  undefinedString: string | undefined
+  nullOrUndefinedString: string | undefined | null
+}
+
+export function test(
+  myObject: MyObject,
+  nullableParam: string | null,
+  undefinedParam: string | undefined,
+  nullOrUndefinedParam: string | undefined | null,
+  unionWithNull: string | number | null,
+  optionalParam?: string
+): string | null {
+  return "test"
+}

--- a/src/test/external_dependencies_test.ts
+++ b/src/test/external_dependencies_test.ts
@@ -1,7 +1,7 @@
 
-import * as test    from "https://deno.land/std@0.208.0/assert/mod.ts";
-import * as path    from "https://deno.land/std@0.208.0/path/mod.ts";
-import * as infer   from '../infer.ts';
+import * as test  from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
+import * as infer from '../infer.ts';
 
 // Skipped due to NPM dependency resolution not currently being supported.
 Deno.test({
@@ -9,41 +9,34 @@ Deno.test({
   fn() {
     const program_path = path.fromFileUrl(import.meta.resolve('./data/external_dependencies.ts'));
     const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
-    const program_results = infer.programInfo(program_path, vendor_path, true);
+    const program_schema = infer.inferProgramSchema(program_path, vendor_path, true);
 
-    test.assertEquals(program_results, {
-      positions: {
-        test_deps: [
-          "s"
-        ]
+    test.assertEquals(program_schema, {
+      scalar_types: {
+        String: {},
       },
-      schema: {
-        scalar_types: {
-          String: {
-            aggregate_functions: {},
-            comparison_operators: {},
-          },
-        },
-        object_types: {},
-        collections: [],
-        functions: [],
-        procedures: [
-          {
-            name: "test_deps",
-            arguments: {
-              s: {
-                type: {
-                  name: "String",
-                  type: "named",
-                },
-              },
-            },
-            result_type: {
-              name: "String",
-              type: "named",
-            },
-          },
-        ],
+      object_types: {},
+      functions: {
+        "test_deps": {
+          ndc_kind: infer.FunctionNdcKind.Procedure,
+          description: null,
+          arguments: [
+            {
+              argument_name: "s",
+              description: null,
+              type: {
+                name: "String",
+                kind: "scalar",
+                type: "named",
+              }
+            }
+          ],
+          result_type: {
+            name: "String",
+            kind: "scalar",
+            type: "named",
+          }
+        }
       }
     });
   }

--- a/src/test/external_dependencies_test.ts
+++ b/src/test/external_dependencies_test.ts
@@ -2,6 +2,7 @@
 import * as test  from "https://deno.land/std@0.208.0/assert/mod.ts";
 import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
 import * as infer from '../infer.ts';
+import { FunctionNdcKind } from "../schema.ts";
 
 // Skipped due to NPM dependency resolution not currently being supported.
 Deno.test("External Dependencies", () => {
@@ -16,7 +17,7 @@ Deno.test("External Dependencies", () => {
     object_types: {},
     functions: {
       "test_deps": {
-        ndc_kind: infer.FunctionNdcKind.Procedure,
+        ndc_kind: FunctionNdcKind.Procedure,
         description: null,
         arguments: [
           {

--- a/src/test/external_dependencies_test.ts
+++ b/src/test/external_dependencies_test.ts
@@ -4,40 +4,37 @@ import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
 import * as infer from '../infer.ts';
 
 // Skipped due to NPM dependency resolution not currently being supported.
-Deno.test({
-  name: "Inference",
-  fn() {
-    const program_path = path.fromFileUrl(import.meta.resolve('./data/external_dependencies.ts'));
-    const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
-    const program_schema = infer.inferProgramSchema(program_path, vendor_path, true);
+Deno.test("External Dependencies", () => {
+  const program_path = path.fromFileUrl(import.meta.resolve('./data/external_dependencies.ts'));
+  const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
+  const program_schema = infer.inferProgramSchema(program_path, vendor_path, true);
 
-    test.assertEquals(program_schema, {
-      scalar_types: {
-        String: {},
-      },
-      object_types: {},
-      functions: {
-        "test_deps": {
-          ndc_kind: infer.FunctionNdcKind.Procedure,
-          description: null,
-          arguments: [
-            {
-              argument_name: "s",
-              description: null,
-              type: {
-                name: "String",
-                kind: "scalar",
-                type: "named",
-              }
+  test.assertEquals(program_schema, {
+    scalar_types: {
+      String: {},
+    },
+    object_types: {},
+    functions: {
+      "test_deps": {
+        ndc_kind: infer.FunctionNdcKind.Procedure,
+        description: null,
+        arguments: [
+          {
+            argument_name: "s",
+            description: null,
+            type: {
+              name: "String",
+              kind: "scalar",
+              type: "named",
             }
-          ],
-          result_type: {
-            name: "String",
-            kind: "scalar",
-            type: "named",
           }
+        ],
+        result_type: {
+          name: "String",
+          kind: "scalar",
+          type: "named",
         }
       }
-    });
-  }
+    }
+  });
 });

--- a/src/test/infer_test.ts
+++ b/src/test/infer_test.ts
@@ -2,6 +2,7 @@
 import * as test  from "https://deno.land/std@0.208.0/assert/mod.ts";
 import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
 import * as infer from '../infer.ts';
+import { FunctionNdcKind, NullOrUndefinability } from "../schema.ts";
 
 Deno.test("Inference", () => {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/program.ts'));
@@ -16,7 +17,7 @@ Deno.test("Inference", () => {
     object_types: {},
     functions: {
       "hello": {
-        ndc_kind: infer.FunctionNdcKind.Procedure,
+        ndc_kind: FunctionNdcKind.Procedure,
         description: null,
         arguments: [],
         result_type: {
@@ -26,7 +27,7 @@ Deno.test("Inference", () => {
         }
       },
       "add": {
-        ndc_kind: infer.FunctionNdcKind.Procedure,
+        ndc_kind: FunctionNdcKind.Procedure,
         description: null,
         arguments: [
           {
@@ -66,7 +67,7 @@ Deno.test("Complex Inference", () => {
   test.assertEquals(program_schema, {
     functions: {
       "complex": {
-        ndc_kind: infer.FunctionNdcKind.Procedure,
+        ndc_kind: FunctionNdcKind.Procedure,
         description: null,
         arguments: [
           {
@@ -92,7 +93,7 @@ Deno.test("Complex Inference", () => {
             description: null,
             type: {
               type: "nullable",
-              null_or_undefinability: infer.NullOrUndefinability.AcceptsUndefinedOnly,
+              null_or_undefinability: NullOrUndefinability.AcceptsUndefinedOnly,
               underlying_type: {
                 name: "String",
                 kind: "scalar",

--- a/src/test/infer_test.ts
+++ b/src/test/infer_test.ts
@@ -1,66 +1,59 @@
 
-import * as test    from "https://deno.land/std@0.208.0/assert/mod.ts";
-import * as path    from "https://deno.land/std@0.208.0/path/mod.ts";
-import * as infer   from '../infer.ts';
+import * as test  from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
+import * as infer from '../infer.ts';
 
 Deno.test("Inference", () => {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/program.ts'));
   const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
-  const program_results = infer.programInfo(program_path, vendor_path, false);
+  const program_schema = infer.inferProgramSchema(program_path, vendor_path, false);
 
-  test.assertEquals(program_results, {
-    positions: {
-      add: [
-        "a",
-        "b",
-      ],
-      hello: [],
+  test.assertEquals(program_schema, {
+    scalar_types: {
+      Float: {},
+      String: {},
     },
-    schema: {
-      scalar_types: {
-        Float: {
-          aggregate_functions: {},
-          comparison_operators: {},
-        },
-        String: {
-          aggregate_functions: {},
-          comparison_operators: {},
-        },
+    object_types: {},
+    functions: {
+      "hello": {
+        ndc_kind: infer.FunctionNdcKind.Procedure,
+        description: null,
+        arguments: [],
+        result_type: {
+          name: "String",
+          kind: "scalar",
+          type: "named",
+        }
       },
-      object_types: {},
-      collections: [],
-      functions: [],
-      procedures: [
-        {
-          arguments: {},
-          name: "hello",
-          result_type: {
-            name: "String",
-            type: "named",
+      "add": {
+        ndc_kind: infer.FunctionNdcKind.Procedure,
+        description: null,
+        arguments: [
+          {
+            argument_name: "a",
+            description: null,
+            type: {
+              name: "Float",
+              kind: "scalar",
+              type: "named",
+            }
           },
-        },
-        {
-          arguments: {
-            a: {
-              type: {
-                name: "Float",
-                type: "named",
-              },
-            },
-            b: {
-              type: {
-                name: "Float",
-                type: "named",
-              },
-            },
-          },
-          name: "add",
-          result_type: {
-            name: "Float",
-            type: "named",
-          },
-        },
-      ],
+          {
+            argument_name: "b",
+            description: null,
+            type: {
+              name: "Float",
+              kind: "scalar",
+              type: "named",
+            }
+          }
+        ],
+        result_type: {
+          name: "Float",
+          kind: "scalar",
+          type: "named",
+        }
+      }
     }
   });
 });
@@ -68,85 +61,86 @@ Deno.test("Inference", () => {
 Deno.test("Complex Inference", () => {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/complex.ts'));
   const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
-  const program_results = infer.programInfo(program_path, vendor_path, true);
+  const program_schema = infer.inferProgramSchema(program_path, vendor_path, true);
 
-  test.assertEquals(program_results, {
-    positions: {
-      complex: [
-        "a",
-        "b",
-        "c",
-      ],
-    },
-    schema: {
-      collections: [],
-      functions: [],
-      object_types: {
-        Result: {
-          fields: {
-            bod: {
-              type: {
+  test.assertEquals(program_schema, {
+    functions: {
+      "complex": {
+        ndc_kind: infer.FunctionNdcKind.Procedure,
+        description: null,
+        arguments: [
+          {
+            argument_name: "a",
+            description: null,
+            type: {
+              name: "Float",
+              kind: "scalar",
+              type: "named",
+            }
+          },
+          {
+            argument_name: "b",
+            description: null,
+            type: {
+              name: "Float",
+              kind: "scalar",
+              type: "named",
+            }
+          },
+          {
+            argument_name: "c",
+            description: null,
+            type: {
+              type: "nullable",
+              null_or_undefinability: infer.NullOrUndefinability.AcceptsUndefinedOnly,
+              underlying_type: {
                 name: "String",
+                kind: "scalar",
                 type: "named",
-              },
-            },
-            num: {
-              type: {
-                name: "Float",
-                type: "named",
-              },
-            },
-            str: {
-              type: {
-                name: "String",
-                type: "named",
-              },
-            },
-          },
-        },
-      },
-      procedures: [
-        {
-          arguments: {
-            a: {
-              type: {
-                name: "Float",
-                type: "named",
-              },
-            },
-            b: {
-              type: {
-                name: "Float",
-                type: "named",
-              },
-            },
-            c: {
-              type: {
-                type: "nullable",
-                underlying_type: {
-                  name: "String",
-                  type: "named",
-                },
-              },
-            },
-          },
-          name: "complex",
-          result_type: {
-            name: "Result",
-            type: "named",
-          },
-        },
-      ],
-      scalar_types: {
-        Float: {
-          aggregate_functions: {},
-          comparison_operators: {},
-        },
-        String: {
-          aggregate_functions: {},
-          comparison_operators: {},
+              }
+            }
+          }
+        ],
+        result_type: {
+          name: "Result",
+          kind: "object",
+          type: "named",
         },
       }
+    },
+    object_types: {
+      Result: {
+        properties: [
+          {
+            property_name: "num",
+            type: {
+              name: "Float",
+              kind: "scalar",
+              type: "named",
+            },
+          },
+          {
+            property_name: "str",
+            type: {
+              name: "String",
+              kind: "scalar",
+              type: "named",
+            },
+          },
+          {
+            property_name: "bod",
+            type: {
+              name: "String",
+              kind: "scalar",
+              type: "named",
+            },
+          },
+        ]
+      },
+    },
+    scalar_types: {
+      Float: {},
+      String: {},
     }
   });
 });

--- a/src/test/inline_types_test.ts
+++ b/src/test/inline_types_test.ts
@@ -3,8 +3,7 @@ import * as test  from "https://deno.land/std@0.208.0/assert/mod.ts";
 import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
 import * as infer from '../infer.ts';
 
-Deno.test({ name: "Type Parameters",
- fn() {
+Deno.test("Inline Types", () => {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/inline_types.ts'));
   const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
 
@@ -63,4 +62,4 @@ Deno.test({ name: "Type Parameters",
     }
   );
 
-}});
+});

--- a/src/test/inline_types_test.ts
+++ b/src/test/inline_types_test.ts
@@ -2,6 +2,7 @@
 import * as test  from "https://deno.land/std@0.208.0/assert/mod.ts";
 import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
 import * as infer from '../infer.ts';
+import { FunctionNdcKind } from "../schema.ts";
 
 Deno.test("Inline Types", () => {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/inline_types.ts'));
@@ -17,7 +18,7 @@ Deno.test("Inline Types", () => {
       },
       functions: {
         "bar": {
-          ndc_kind: infer.FunctionNdcKind.Procedure,
+          ndc_kind: FunctionNdcKind.Procedure,
           description: null,
           arguments: [
             {

--- a/src/test/inline_types_test.ts
+++ b/src/test/inline_types_test.ts
@@ -1,73 +1,64 @@
 
-import * as test    from "https://deno.land/std@0.208.0/assert/mod.ts";
-import * as path    from "https://deno.land/std@0.208.0/path/mod.ts";
-import * as infer   from '../infer.ts';
+import * as test  from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
+import * as infer from '../infer.ts';
 
 Deno.test({ name: "Type Parameters",
- ignore: false,
  fn() {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/inline_types.ts'));
   const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
 
-  const program_results = infer.programInfo(program_path, vendor_path, false);
+  const program_schema = infer.inferProgramSchema(program_path, vendor_path, false);
 
-  // TODO: Currently broken since parameters aren't normalised
-
-  test.assertEquals(program_results, 
+  test.assertEquals(program_schema,
     {
-      "schema": {
-        "scalar_types": {
-          "String": {
-            "aggregate_functions": {},
-            "comparison_operators": {},
-          },
-          "Float": {
-            "aggregate_functions": {},
-            "comparison_operators": {},
-          }
-        },
-        "object_types": {
-          "bar_arguments_x": {
-            "fields": {
-              "a": {
-                "type": {
-                  "type": "named",
-                  "name": "Float"
-                }
-              },
-              "b": {
-                "type": {
-                  "type": "named",
-                  "name": "String"
-                }
+      scalar_types: {
+        String: {},
+        Float: {}
+      },
+      functions: {
+        "bar": {
+          ndc_kind: infer.FunctionNdcKind.Procedure,
+          description: null,
+          arguments: [
+            {
+              argument_name: "x",
+              description: null,
+              type: {
+                type: "named",
+                kind: "object",
+                name: "bar_arguments_x"
               }
             }
+          ],
+          result_type: {
+            type: "named",
+            kind: "scalar",
+            name: "String"
           }
-        },
-        "collections": [],
-        "functions": [],
-        "procedures": [
-          {
-            "name": "bar",
-            "arguments": {
-              "x": {
-                "type": {
-                  "type": "named",
-                  "name": "bar_arguments_x"
-                }
+        }
+      },
+      object_types: {
+        "bar_arguments_x": {
+          properties: [
+            {
+              property_name: "a",
+              type: {
+                type: "named",
+                kind: "scalar",
+                name: "Float"
               }
             },
-            "result_type": {
-              "type": "named",
-              "name": "String"
-            }
-          }
-        ]
-      },
-      "positions": {
-        "bar": [
-          "x"
-        ]
+            {
+              property_name: "b",
+              type: {
+                type: "named",
+                kind: "scalar",
+                name: "String"
+              }
+            },
+          ]
+        }
       }
     }
   );

--- a/src/test/ndc_schema_test.ts
+++ b/src/test/ndc_schema_test.ts
@@ -1,0 +1,172 @@
+import * as test from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as infer from '../infer.ts';
+import { ProgramSchema } from '../infer.ts';
+
+Deno.test("NDC Schema Generation", () => {
+  const program_schema: ProgramSchema = {
+    functions: {
+      "test_proc": {
+        arguments: [
+          {
+            argument_name: "nullableParam",
+            description: null,
+            type: {
+              type: "nullable",
+              null_or_undefinability: infer.NullOrUndefinability.AcceptsNullOnly,
+              underlying_type: {
+                kind: "scalar",
+                name: "String",
+                type: "named",
+              },
+            },
+          },
+        ],
+        description: null,
+        ndc_kind: infer.FunctionNdcKind.Procedure,
+        result_type: {
+          type: "nullable",
+          null_or_undefinability: infer.NullOrUndefinability.AcceptsNullOnly,
+          underlying_type: {
+            kind: "scalar",
+            name: "String",
+            type: "named",
+          }
+        },
+      },
+      "test_func": {
+        arguments: [
+          {
+            argument_name: "myObject",
+            description: null,
+            type: {
+              kind: "object",
+              name: "MyObject",
+              type: "named",
+            },
+          },
+        ],
+        description: null,
+        ndc_kind: infer.FunctionNdcKind.Function,
+        result_type: {
+          type: "array",
+          element_type: {
+            kind: "scalar",
+            name: "String",
+            type: "named",
+          }
+        },
+      },
+    },
+    object_types: {
+      "MyObject": {
+        properties: [
+          {
+            property_name: "string",
+            type: {
+              kind: "scalar",
+              name: "String",
+              type: "named",
+            },
+          },
+          {
+            property_name: "nullableString",
+            type: {
+              type: "nullable",
+              null_or_undefinability: infer.NullOrUndefinability.AcceptsNullOnly,
+              underlying_type: {
+                kind: "scalar",
+                name: "String",
+                type: "named",
+              },
+            },
+          },
+        ],
+      },
+    },
+    scalar_types: {
+      String: {},
+      test_arguments_unionWithNull: {},
+    },
+  };
+
+  const schema_response = infer.get_ndc_schema(program_schema)
+
+  test.assertEquals(schema_response, {
+    collections: [],
+    functions: [
+      {
+        name: "test_func",
+        arguments: {
+          "myObject": {
+            type: {
+              name: "MyObject",
+              type: "named",
+            },
+          },
+        },
+        result_type: {
+          type: "array",
+          element_type: {
+            name: "String",
+            type: "named",
+          }
+        },
+      },
+    ],
+    procedures: [
+      {
+        name: "test_proc",
+        arguments: {
+          "nullableParam": {
+            type: {
+              type: "nullable",
+              underlying_type: {
+                name: "String",
+                type: "named",
+              },
+            },
+          },
+        },
+        result_type: {
+          type: "nullable",
+          underlying_type: {
+            name: "String",
+            type: "named",
+          }
+        },
+      }
+    ],
+    object_types: {
+      "MyObject": {
+        fields: {
+          "string": {
+            type: {
+              name: "String",
+              type: "named",
+            },
+          },
+          "nullableString": {
+            type: {
+              type: "nullable",
+              underlying_type: {
+                name: "String",
+                type: "named",
+              },
+            },
+          },
+        },
+      },
+    },
+    scalar_types: {
+      String: {
+        aggregate_functions: {},
+        comparison_operators: {}
+      },
+      test_arguments_unionWithNull: {
+        aggregate_functions: {},
+        comparison_operators: {}
+      },
+    }
+  });
+
+});

--- a/src/test/ndc_schema_test.ts
+++ b/src/test/ndc_schema_test.ts
@@ -1,6 +1,5 @@
 import * as test from "https://deno.land/std@0.208.0/assert/mod.ts";
-import * as infer from '../infer.ts';
-import { ProgramSchema } from '../infer.ts';
+import { FunctionNdcKind, NullOrUndefinability, ProgramSchema, get_ndc_schema } from "../schema.ts";
 
 Deno.test("NDC Schema Generation", () => {
   const program_schema: ProgramSchema = {
@@ -12,7 +11,7 @@ Deno.test("NDC Schema Generation", () => {
             description: null,
             type: {
               type: "nullable",
-              null_or_undefinability: infer.NullOrUndefinability.AcceptsNullOnly,
+              null_or_undefinability: NullOrUndefinability.AcceptsNullOnly,
               underlying_type: {
                 kind: "scalar",
                 name: "String",
@@ -22,10 +21,10 @@ Deno.test("NDC Schema Generation", () => {
           },
         ],
         description: null,
-        ndc_kind: infer.FunctionNdcKind.Procedure,
+        ndc_kind: FunctionNdcKind.Procedure,
         result_type: {
           type: "nullable",
-          null_or_undefinability: infer.NullOrUndefinability.AcceptsNullOnly,
+          null_or_undefinability: NullOrUndefinability.AcceptsNullOnly,
           underlying_type: {
             kind: "scalar",
             name: "String",
@@ -46,7 +45,7 @@ Deno.test("NDC Schema Generation", () => {
           },
         ],
         description: null,
-        ndc_kind: infer.FunctionNdcKind.Function,
+        ndc_kind: FunctionNdcKind.Function,
         result_type: {
           type: "array",
           element_type: {
@@ -72,7 +71,7 @@ Deno.test("NDC Schema Generation", () => {
             property_name: "nullableString",
             type: {
               type: "nullable",
-              null_or_undefinability: infer.NullOrUndefinability.AcceptsNullOnly,
+              null_or_undefinability: NullOrUndefinability.AcceptsNullOnly,
               underlying_type: {
                 kind: "scalar",
                 name: "String",
@@ -89,7 +88,7 @@ Deno.test("NDC Schema Generation", () => {
     },
   };
 
-  const schema_response = infer.get_ndc_schema(program_schema)
+  const schema_response = get_ndc_schema(program_schema)
 
   test.assertEquals(schema_response, {
     collections: [],

--- a/src/test/nullable_types_test.ts
+++ b/src/test/nullable_types_test.ts
@@ -1,0 +1,165 @@
+import * as test  from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
+import * as infer from '../infer.ts';
+
+Deno.test("Nullable Types", () => {
+  const program_path = path.fromFileUrl(import.meta.resolve('./data/nullable_types.ts'));
+  const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
+  const program_schema = infer.inferProgramSchema(program_path, vendor_path, false);
+
+  test.assertEquals(program_schema, {
+    functions: {
+      "test": {
+        arguments: [
+          {
+            argument_name: "myObject",
+            description: null,
+            type: {
+              kind: "object",
+              name: "MyObject",
+              type: "named",
+            },
+          },
+          {
+            argument_name: "nullableParam",
+            description: null,
+            type: {
+              type: "nullable",
+              null_or_undefinability: infer.NullOrUndefinability.AcceptsNullOnly,
+              underlying_type: {
+                kind: "scalar",
+                name: "String",
+                type: "named",
+              },
+            },
+          },
+          {
+            argument_name: "undefinedParam",
+            description: null,
+            type: {
+              type: "nullable",
+              null_or_undefinability: infer.NullOrUndefinability.AcceptsUndefinedOnly,
+              underlying_type: {
+                kind: "scalar",
+                name: "String",
+                type: "named",
+              },
+            },
+          },
+          {
+            argument_name: "nullOrUndefinedParam",
+            description: null,
+            type: {
+              type: "nullable",
+              null_or_undefinability: infer.NullOrUndefinability.AcceptsEither,
+              underlying_type: {
+                kind: "scalar",
+                name: "String",
+                type: "named",
+              },
+            },
+          },
+          {
+            argument_name: "unionWithNull",
+            description: null,
+            type: {
+              kind: "scalar",
+              name: "test_arguments_unionWithNull",
+              type: "named",
+            },
+          },
+          {
+            argument_name: "optionalParam",
+            description: null,
+            type: {
+              type: "nullable",
+              null_or_undefinability: infer.NullOrUndefinability.AcceptsUndefinedOnly,
+              underlying_type: {
+                kind: "scalar",
+                name: "String",
+                type: "named",
+              },
+            },
+          },
+        ],
+        description: null,
+        ndc_kind: infer.FunctionNdcKind.Procedure,
+        result_type: {
+          type: "nullable",
+          null_or_undefinability: infer.NullOrUndefinability.AcceptsNullOnly,
+          underlying_type: {
+            kind: "scalar",
+            name: "String",
+            type: "named",
+          }
+        },
+      },
+    },
+    object_types: {
+      "MyObject": {
+        properties: [
+          {
+            property_name: "string",
+            type: {
+              kind: "scalar",
+              name: "String",
+              type: "named",
+            },
+          },
+          {
+            property_name: "nullableString",
+            type: {
+              type: "nullable",
+              null_or_undefinability: infer.NullOrUndefinability.AcceptsNullOnly,
+              underlying_type: {
+                kind: "scalar",
+                name: "String",
+                type: "named",
+              },
+            },
+          },
+          {
+            property_name: "optionalString",
+            type: {
+              type: "nullable",
+              null_or_undefinability: infer.NullOrUndefinability.AcceptsUndefinedOnly,
+              underlying_type: {
+                kind: "scalar",
+                name: "String",
+                type: "named",
+              },
+            },
+          },
+          {
+            property_name: "undefinedString",
+            type: {
+              type: "nullable",
+              null_or_undefinability: infer.NullOrUndefinability.AcceptsUndefinedOnly,
+              underlying_type: {
+                kind: "scalar",
+                name: "String",
+                type: "named",
+              },
+            },
+          },
+          {
+            property_name: "nullOrUndefinedString",
+            type: {
+              type: "nullable",
+              null_or_undefinability: infer.NullOrUndefinability.AcceptsEither,
+              underlying_type: {
+                kind: "scalar",
+                name: "String",
+                type: "named",
+              },
+            },
+          },
+        ],
+      },
+    },
+    scalar_types: {
+      String: {},
+      test_arguments_unionWithNull: {},
+    },
+  });
+});

--- a/src/test/nullable_types_test.ts
+++ b/src/test/nullable_types_test.ts
@@ -1,6 +1,7 @@
 import * as test  from "https://deno.land/std@0.208.0/assert/mod.ts";
 import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
 import * as infer from '../infer.ts';
+import { FunctionNdcKind, NullOrUndefinability } from "../schema.ts";
 
 Deno.test("Nullable Types", () => {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/nullable_types.ts'));
@@ -25,7 +26,7 @@ Deno.test("Nullable Types", () => {
             description: null,
             type: {
               type: "nullable",
-              null_or_undefinability: infer.NullOrUndefinability.AcceptsNullOnly,
+              null_or_undefinability: NullOrUndefinability.AcceptsNullOnly,
               underlying_type: {
                 kind: "scalar",
                 name: "String",
@@ -38,7 +39,7 @@ Deno.test("Nullable Types", () => {
             description: null,
             type: {
               type: "nullable",
-              null_or_undefinability: infer.NullOrUndefinability.AcceptsUndefinedOnly,
+              null_or_undefinability: NullOrUndefinability.AcceptsUndefinedOnly,
               underlying_type: {
                 kind: "scalar",
                 name: "String",
@@ -51,7 +52,7 @@ Deno.test("Nullable Types", () => {
             description: null,
             type: {
               type: "nullable",
-              null_or_undefinability: infer.NullOrUndefinability.AcceptsEither,
+              null_or_undefinability: NullOrUndefinability.AcceptsEither,
               underlying_type: {
                 kind: "scalar",
                 name: "String",
@@ -73,7 +74,7 @@ Deno.test("Nullable Types", () => {
             description: null,
             type: {
               type: "nullable",
-              null_or_undefinability: infer.NullOrUndefinability.AcceptsUndefinedOnly,
+              null_or_undefinability: NullOrUndefinability.AcceptsUndefinedOnly,
               underlying_type: {
                 kind: "scalar",
                 name: "String",
@@ -83,10 +84,10 @@ Deno.test("Nullable Types", () => {
           },
         ],
         description: null,
-        ndc_kind: infer.FunctionNdcKind.Procedure,
+        ndc_kind: FunctionNdcKind.Procedure,
         result_type: {
           type: "nullable",
-          null_or_undefinability: infer.NullOrUndefinability.AcceptsNullOnly,
+          null_or_undefinability: NullOrUndefinability.AcceptsNullOnly,
           underlying_type: {
             kind: "scalar",
             name: "String",
@@ -110,7 +111,7 @@ Deno.test("Nullable Types", () => {
             property_name: "nullableString",
             type: {
               type: "nullable",
-              null_or_undefinability: infer.NullOrUndefinability.AcceptsNullOnly,
+              null_or_undefinability: NullOrUndefinability.AcceptsNullOnly,
               underlying_type: {
                 kind: "scalar",
                 name: "String",
@@ -122,7 +123,7 @@ Deno.test("Nullable Types", () => {
             property_name: "optionalString",
             type: {
               type: "nullable",
-              null_or_undefinability: infer.NullOrUndefinability.AcceptsUndefinedOnly,
+              null_or_undefinability: NullOrUndefinability.AcceptsUndefinedOnly,
               underlying_type: {
                 kind: "scalar",
                 name: "String",
@@ -134,7 +135,7 @@ Deno.test("Nullable Types", () => {
             property_name: "undefinedString",
             type: {
               type: "nullable",
-              null_or_undefinability: infer.NullOrUndefinability.AcceptsUndefinedOnly,
+              null_or_undefinability: NullOrUndefinability.AcceptsUndefinedOnly,
               underlying_type: {
                 kind: "scalar",
                 name: "String",
@@ -146,7 +147,7 @@ Deno.test("Nullable Types", () => {
             property_name: "nullOrUndefinedString",
             type: {
               type: "nullable",
-              null_or_undefinability: infer.NullOrUndefinability.AcceptsEither,
+              null_or_undefinability: NullOrUndefinability.AcceptsEither,
               underlying_type: {
                 kind: "scalar",
                 name: "String",

--- a/src/test/pg_dep_test.ts
+++ b/src/test/pg_dep_test.ts
@@ -2,6 +2,7 @@
 import * as test  from "https://deno.land/std@0.208.0/assert/mod.ts";
 import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
 import * as infer from '../infer.ts';
+import { FunctionNdcKind } from "../schema.ts";
 
 // NOTE: It would be good to have explicit timeout for this
 // See: https://github.com/denoland/deno/issues/11133
@@ -14,7 +15,7 @@ Deno.test("Postgres NPM Dependency", () => {
   test.assertEquals(program_schema, {
     functions: {
       "insert_user": {
-        ndc_kind: infer.FunctionNdcKind.Procedure,
+        ndc_kind: FunctionNdcKind.Procedure,
         description: null,
         arguments: [
           {
@@ -34,7 +35,7 @@ Deno.test("Postgres NPM Dependency", () => {
         }
       },
       "insert_todos": {
-        ndc_kind: infer.FunctionNdcKind.Procedure,
+        ndc_kind: FunctionNdcKind.Procedure,
         description: null,
         arguments: [
           {
@@ -63,7 +64,7 @@ Deno.test("Postgres NPM Dependency", () => {
         }
       },
       "delete_todos": {
-        ndc_kind: infer.FunctionNdcKind.Procedure,
+        ndc_kind: FunctionNdcKind.Procedure,
         description: null,
         arguments: [
           {

--- a/src/test/pg_dep_test.ts
+++ b/src/test/pg_dep_test.ts
@@ -6,7 +6,7 @@ import * as infer from '../infer.ts';
 // NOTE: It would be good to have explicit timeout for this
 // See: https://github.com/denoland/deno/issues/11133
 // Test bug: https://github.com/hasura/ndc-typescript-deno/issues/45
-Deno.test("Inferred Dependency Based Result Type", () => {
+Deno.test("Postgres NPM Dependency", () => {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/pg_dep.ts'));
   const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
   const program_schema = infer.inferProgramSchema(program_path, vendor_path, true);

--- a/src/test/pg_dep_test.ts
+++ b/src/test/pg_dep_test.ts
@@ -1,7 +1,7 @@
 
-import * as test    from "https://deno.land/std@0.208.0/assert/mod.ts";
-import * as path    from "https://deno.land/std@0.208.0/path/mod.ts";
-import * as infer   from '../infer.ts';
+import * as test  from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
+import * as infer from '../infer.ts';
 
 // NOTE: It would be good to have explicit timeout for this
 // See: https://github.com/denoland/deno/issues/11133
@@ -9,92 +9,85 @@ import * as infer   from '../infer.ts';
 Deno.test("Inferred Dependency Based Result Type", () => {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/pg_dep.ts'));
   const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
-  const program_results = infer.programInfo(program_path, vendor_path, true);
+  const program_schema = infer.inferProgramSchema(program_path, vendor_path, true);
 
-  test.assertEquals(program_results, {
-    positions: {
-      delete_todos: [
-        "todo_id",
-      ],
-      insert_todos: [
-        "user_id",
-        "todo",
-      ],
-      insert_user: [
-        "user_name",
-      ],
-    },
-    schema: {
-      collections: [],
-      functions: [],
-      procedures: [
-        {
-          arguments: {
-            user_name: {
-              type: {
-                name: "String",
-                type: "named",
-              },
-            },
-          },
-          name: "insert_user",
-          result_type: {
-            name: "insert_user_output",
-            type: "named",
-          },
-        },
-        {
-          arguments: {
-            todo: {
-              type: {
-                name: "String",
-                type: "named",
-              },
-            },
-            user_id: {
-              type: {
-                name: "String",
-                type: "named",
-              },
-            },
-          },
-          name: "insert_todos",
-          result_type: {
-            name: "insert_todos_output",
-            type: "named",
-          },
-        },
-        {
-          arguments: {
-            todo_id: {
-              type: {
-                name: "String",
-                type: "named",
-              },
-            },
-          },
-          name: "delete_todos",
-          result_type: {
-            name: "String",
-            type: "named",
-          },
-        },
-      ],
-      scalar_types: {
-        String: {
-          aggregate_functions: {},
-          comparison_operators: {},
-        },
-        insert_todos_output: {
-          aggregate_functions: {},
-          comparison_operators: {},
-        },
-        insert_user_output: {
-          aggregate_functions: {},
-          comparison_operators: {},
-        },
+  test.assertEquals(program_schema, {
+    functions: {
+      "insert_user": {
+        ndc_kind: infer.FunctionNdcKind.Procedure,
+        description: null,
+        arguments: [
+          {
+            argument_name: "user_name",
+            description: null,
+            type: {
+              type: "named",
+              kind: "scalar",
+              name: "String"
+            }
+          }
+        ],
+        result_type: {
+          type: "named",
+          kind: "scalar",
+          name: "insert_user_output"
+        }
       },
-      object_types: {},
-    }
+      "insert_todos": {
+        ndc_kind: infer.FunctionNdcKind.Procedure,
+        description: null,
+        arguments: [
+          {
+            argument_name: "user_id",
+            description: null,
+            type: {
+              type: "named",
+              kind: "scalar",
+              name: "String"
+            }
+          },
+          {
+            argument_name: "todo",
+            description: null,
+            type: {
+              type: "named",
+              kind: "scalar",
+              name: "String"
+            }
+          },
+        ],
+        result_type: {
+          type: "named",
+          kind: "scalar",
+          name: "insert_todos_output"
+        }
+      },
+      "delete_todos": {
+        ndc_kind: infer.FunctionNdcKind.Procedure,
+        description: null,
+        arguments: [
+          {
+            argument_name: "todo_id",
+            description: null,
+            type: {
+              type: "named",
+              kind: "scalar",
+              name: "String"
+            }
+          }
+        ],
+        result_type: {
+          type: "named",
+          kind: "scalar",
+          name: "String"
+        }
+      },
+    },
+    scalar_types: {
+      String: {},
+      insert_todos_output: {},
+      insert_user_output: {},
+    },
+    object_types: {},
   });
 });

--- a/src/test/prepare_arguments_test.ts
+++ b/src/test/prepare_arguments_test.ts
@@ -1,0 +1,319 @@
+import * as test from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as connector from '../connector.ts';
+import { FunctionDefinitions, FunctionNdcKind, NullOrUndefinability, ObjectTypeDefinitions } from "../infer.ts";
+
+Deno.test("argument ordering", () => {
+  const function_name = "test_fn"
+  const function_definitions: FunctionDefinitions = {
+    [function_name]: {
+      ndc_kind: FunctionNdcKind.Function,
+      description: null,
+      arguments: [
+        {
+          argument_name: "c",
+          description: null,
+          type: {
+            type: "named",
+            kind: "scalar",
+            name: "Float"
+          }
+        },
+        {
+          argument_name: "a",
+          description: null,
+          type: {
+            type: "named",
+            kind: "scalar",
+            name: "Float"
+          }
+        },
+        {
+          argument_name: "b",
+          description: null,
+          type: {
+            type: "named",
+            kind: "scalar",
+            name: "Float"
+          }
+        },
+      ],
+      result_type: {
+        type: "named",
+        kind: "scalar",
+        name: "String"
+      }
+    }
+  }
+  const object_types: ObjectTypeDefinitions = {}
+  const args = {
+    b: 1,
+    a: 2,
+    c: 3,
+  }
+
+  const prepared_args = connector.prepare_arguments(function_name, args, function_definitions, object_types);
+
+  test.assertEquals(prepared_args, [ 3, 2, 1 ]);
+})
+
+Deno.test("nullable type coercion", async t => {
+  const function_name = "test_fn"
+  const function_definitions: FunctionDefinitions = {
+    [function_name]: {
+      ndc_kind: FunctionNdcKind.Function,
+      description: null,
+      arguments: [
+        {
+          argument_name: "nullOnlyArg",
+          description: null,
+          type: {
+            type: "nullable",
+            null_or_undefinability: NullOrUndefinability.AcceptsNullOnly,
+            underlying_type: {
+              type: "named",
+              kind: "scalar",
+              name: "String"
+            }
+          }
+        },
+        {
+          argument_name: "undefinedOnlyArg",
+          description: null,
+          type: {
+            type: "nullable",
+            null_or_undefinability: NullOrUndefinability.AcceptsUndefinedOnly,
+            underlying_type: {
+              type: "named",
+              kind: "scalar",
+              name: "String"
+            }
+          }
+        },
+        {
+          argument_name: "nullOrUndefinedArg",
+          description: null,
+          type: {
+            type: "nullable",
+            null_or_undefinability: NullOrUndefinability.AcceptsEither,
+            underlying_type: {
+              type: "named",
+              kind: "scalar",
+              name: "String"
+            }
+          }
+        },
+        {
+          argument_name: "objectArg",
+          description: null,
+          type: {
+            type: "named",
+            kind: "object",
+            name: "MyObject",
+          }
+        },
+        {
+          argument_name: "nullOnlyArrayArg",
+          description: null,
+          type: {
+            type: "array",
+            element_type: {
+              type: "nullable",
+              null_or_undefinability: NullOrUndefinability.AcceptsNullOnly,
+              underlying_type: {
+                type: "named",
+                kind: "scalar",
+                name: "String"
+              }
+            }
+          }
+        },
+        {
+          argument_name: "undefinedOnlyArrayArg",
+          description: null,
+          type: {
+            type: "array",
+            element_type: {
+              type: "nullable",
+              null_or_undefinability: NullOrUndefinability.AcceptsUndefinedOnly,
+              underlying_type: {
+                type: "named",
+                kind: "scalar",
+                name: "String"
+              }
+            }
+          }
+        },
+        {
+          argument_name: "nullOrUndefinedArrayArg",
+          description: null,
+          type: {
+            type: "array",
+            element_type: {
+              type: "nullable",
+              null_or_undefinability: NullOrUndefinability.AcceptsEither,
+              underlying_type: {
+                type: "named",
+                kind: "scalar",
+                name: "String"
+              }
+            }
+          }
+        },
+      ],
+      result_type: {
+        type: "named",
+        kind: "scalar",
+        name: "String"
+      }
+    }
+  }
+  const object_types: ObjectTypeDefinitions = {
+    "MyObject": {
+      properties: [
+        {
+          property_name: "nullOnlyProp",
+          type: {
+            type: "nullable",
+            null_or_undefinability: NullOrUndefinability.AcceptsNullOnly,
+            underlying_type: {
+              type: "named",
+              kind: "scalar",
+              name: "String"
+            }
+          }
+        },
+        {
+          property_name: "undefinedOnlyProp",
+          type: {
+            type: "nullable",
+            null_or_undefinability: NullOrUndefinability.AcceptsUndefinedOnly,
+            underlying_type: {
+              type: "named",
+              kind: "scalar",
+              name: "String"
+            }
+          }
+        },
+        {
+          property_name: "nullOrUndefinedProp",
+          type: {
+            type: "nullable",
+            null_or_undefinability: NullOrUndefinability.AcceptsEither,
+            underlying_type: {
+              type: "named",
+              kind: "scalar",
+              name: "String"
+            }
+          }
+        }
+      ]
+    }
+  }
+  const test_cases = [
+    {
+      name: "all nulls",
+      args: {
+        nullOnlyArg: null,
+        undefinedOnlyArg: null,
+        nullOrUndefinedArg: null,
+        objectArg: {
+          nullOnlyProp: null,
+          undefinedOnlyProp: null,
+          nullOrUndefinedProp: null,
+        },
+        nullOnlyArrayArg: [null, null],
+        undefinedOnlyArrayArg: [null, null],
+        nullOrUndefinedArrayArg: [null, null],
+      },
+      expected: [
+        null,
+        undefined,
+        null,
+        { nullOnlyProp: null, undefinedOnlyProp: undefined, nullOrUndefinedProp: null },
+        [null, null],
+        [undefined, undefined],
+        [null, null],
+      ]
+    },
+    {
+      name: "all undefineds",
+      args: {
+        nullOnlyArg: undefined,
+        undefinedOnlyArg: undefined,
+        nullOrUndefinedArg: undefined,
+        objectArg: {
+          nullOnlyProp: undefined,
+          undefinedOnlyProp: undefined,
+          nullOrUndefinedProp: undefined,
+        },
+        nullOnlyArrayArg: [undefined, undefined],
+        undefinedOnlyArrayArg: [undefined, undefined],
+        nullOrUndefinedArrayArg: [undefined, undefined],
+      },
+      expected: [
+        null,
+        undefined,
+        undefined,
+        { nullOnlyProp: null, undefinedOnlyProp: undefined, nullOrUndefinedProp: undefined },
+        [null, null],
+        [undefined, undefined],
+        [undefined, undefined],
+      ]
+    },
+    {
+      name: "all missing",
+      args: {
+        objectArg: {},
+        nullOnlyArrayArg: [],
+        undefinedOnlyArrayArg: [],
+        nullOrUndefinedArrayArg: [],
+      },
+      expected: [
+        null,
+        undefined,
+        undefined,
+        { nullOnlyProp: null, undefinedOnlyProp: undefined, nullOrUndefinedProp: undefined },
+        [],
+        [],
+        [],
+      ]
+    },
+    {
+      name: "all valued",
+      args: {
+        nullOnlyArg: "a",
+        undefinedOnlyArg: "b",
+        nullOrUndefinedArg: "c",
+        objectArg: {
+          nullOnlyProp: "d",
+          undefinedOnlyProp: "e",
+          nullOrUndefinedProp: "f",
+        },
+        nullOnlyArrayArg: ["g", "h"],
+        undefinedOnlyArrayArg: ["i", "j"],
+        nullOrUndefinedArrayArg: ["k", "l"],
+      },
+      expected: [
+        "a",
+        "b",
+        "c",
+        { nullOnlyProp: "d", undefinedOnlyProp: "e", nullOrUndefinedProp: "f" },
+        ["g", "h"],
+        ["i", "j"],
+        ["k", "l"],
+      ]
+    },
+  ];
+
+  await Promise.all(test_cases.map(test_case => t.step({
+    name: test_case.name,
+    fn: () => {
+      const prepared_args = connector.prepare_arguments(function_name, test_case.args, function_definitions, object_types);
+      test.assertEquals(prepared_args, test_case.expected);
+    },
+    sanitizeOps: false,
+    sanitizeResources: false,
+    sanitizeExit: false,
+  })));
+
+})

--- a/src/test/prepare_arguments_test.ts
+++ b/src/test/prepare_arguments_test.ts
@@ -1,6 +1,6 @@
 import * as test from "https://deno.land/std@0.208.0/assert/mod.ts";
 import * as connector from '../connector.ts';
-import { FunctionDefinitions, FunctionNdcKind, NullOrUndefinability, ObjectTypeDefinitions } from "../infer.ts";
+import { FunctionDefinitions, FunctionNdcKind, NullOrUndefinability, ObjectTypeDefinitions } from "../schema.ts";
 
 Deno.test("argument ordering", () => {
   const function_name = "test_fn"

--- a/src/test/recursive_types_test.ts
+++ b/src/test/recursive_types_test.ts
@@ -7,52 +7,48 @@ Deno.test("Recursive Types", () => {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/recursive.ts'));
   const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
 
-  const program_results = infer.programInfo(program_path, vendor_path, false);
+  const program_schema = infer.inferProgramSchema(program_path, vendor_path, false);
 
-  test.assertEquals(program_results, {
-    positions: {
-      bar: [],
+  test.assertEquals(program_schema, {
+    functions: {
+      "bar": {
+        ndc_kind: infer.FunctionNdcKind.Procedure,
+        description: null,
+        arguments: [],
+        result_type: {
+          type: "named",
+          kind: "object",
+          name: "Foo"
+        }
+      }
     },
-    schema: {
-      collections: [],
-      functions: [],
-      object_types: {
-        Foo: {
-          fields: {
-            a: {
-              type: {
-                name: "Float",
+    object_types: {
+      Foo: {
+        properties: [
+          {
+            property_name: "a",
+            type: {
+              type: "named",
+              kind: "scalar",
+              name: "Float"
+            }
+          },
+          {
+            property_name: "b",
+            type: {
+              type: "array",
+              element_type: {
                 type: "named",
-              },
-            },
-            b: {
-              type: {
-                element_type: {
-                  name: "Foo",
-                  type: "named",
-                },
-                type: "array",
-              },
-            },
-          },
-        },
+                kind: "object",
+                name: "Foo"
+              }
+            }
+          }
+        ]
       },
-      procedures: [
-        {
-          arguments: {},
-          name: "bar",
-          result_type: {
-            name: "Foo",
-            type: "named",
-          },
-        },
-      ],
-      scalar_types: {
-        Float: {
-          aggregate_functions: {},
-          comparison_operators: {},
-        },
-      },
-    }
+    },
+    scalar_types: {
+      Float: {},
+    },
   });
 });

--- a/src/test/recursive_types_test.ts
+++ b/src/test/recursive_types_test.ts
@@ -2,6 +2,7 @@
 import * as test  from "https://deno.land/std@0.208.0/assert/mod.ts";
 import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
 import * as infer from '../infer.ts';
+import { FunctionNdcKind } from "../schema.ts";
 
 Deno.test("Recursive Types", () => {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/recursive.ts'));
@@ -12,7 +13,7 @@ Deno.test("Recursive Types", () => {
   test.assertEquals(program_schema, {
     functions: {
       "bar": {
-        ndc_kind: infer.FunctionNdcKind.Procedure,
+        ndc_kind: FunctionNdcKind.Procedure,
         description: null,
         arguments: [],
         result_type: {

--- a/src/test/type_parameters_test.ts
+++ b/src/test/type_parameters_test.ts
@@ -1,7 +1,7 @@
 
-import * as test    from "https://deno.land/std@0.208.0/assert/mod.ts";
-import * as path    from "https://deno.land/std@0.208.0/path/mod.ts";
-import * as infer   from '../infer.ts';
+import * as test  from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
+import * as infer from '../infer.ts';
 
 Deno.test({ name: "Type Parameters",
  ignore: false,
@@ -9,72 +9,69 @@ Deno.test({ name: "Type Parameters",
   const program_path = path.fromFileUrl(import.meta.resolve('./data/type_parameters.ts'));
   const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
 
-  const program_results = infer.programInfo(program_path, vendor_path, false);
+  const program_schema = infer.inferProgramSchema(program_path, vendor_path, false);
 
   // TODO: Currently broken since parameters aren't normalised
 
-  test.assertEquals(program_results, {
-    positions: {
-      bar: [],
+  test.assertEquals(program_schema, {
+    functions: {
+      "bar": {
+        ndc_kind: infer.FunctionNdcKind.Procedure,
+        description: null,
+        arguments: [],
+        result_type: {
+          name: "Bar<Foo>",
+          kind: "object",
+          type: "named",
+        }
+      }
     },
-    schema: {
-      collections: [],
-      functions: [],
-      object_types: {
-        "Bar<Foo>": {
-          fields: {
-            x: {
-              type: {
-                name: "Float",
-                type: "named",
-              },
-            },
-            y: {
-              type: {
-                name: "Foo",
-                type: "named",
-              },
-            },
+    object_types: {
+      "Bar<Foo>": {
+        properties: [
+          {
+            property_name: "x",
+            type: {
+              type: "named",
+              kind: "scalar",
+              name: "Float"
+            }
           },
-        },
-        "Foo": {
-          fields: {
-            a: {
-              type: {
-                name: "Float",
-                type: "named",
-              },
-            },
-            b: {
-              type: {
-                name: "String",
-                type: "named",
-              },
-            },
+          {
+            property_name: "y",
+            type: {
+              type: "named",
+              kind: "object",
+              name: "Foo"
+            }
           },
-        },
+        ]
       },
-      scalar_types: {
-        Float: {
-          aggregate_functions: {},
-          comparison_operators: {},
-        },
-        String: {
-          aggregate_functions: {},
-          comparison_operators: {},
-        },
-      },
-      procedures: [
-        {
-          arguments: {},
-          name: "bar",
-          result_type: {
-            name: "Bar<Foo>",
-            type: "named",
+      "Foo": {
+        properties: [
+          {
+            property_name: "a",
+            type: {
+              type: "named",
+              kind: "scalar",
+              name: "Float"
+            }
           },
-        },
-      ],
-    }
+          {
+            property_name: "b",
+            type: {
+              type: "named",
+              kind: "scalar",
+              name: "String"
+            }
+          },
+        ]
+      },
+    },
+    scalar_types: {
+      Float: {},
+      String: {},
+    },
   });
 
 }});

--- a/src/test/type_parameters_test.ts
+++ b/src/test/type_parameters_test.ts
@@ -3,9 +3,7 @@ import * as test  from "https://deno.land/std@0.208.0/assert/mod.ts";
 import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
 import * as infer from '../infer.ts';
 
-Deno.test({ name: "Type Parameters",
- ignore: false,
- fn() {
+Deno.test("Type Parameters", () => {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/type_parameters.ts'));
   const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
 
@@ -74,4 +72,4 @@ Deno.test({ name: "Type Parameters",
     },
   });
 
-}});
+});

--- a/src/test/type_parameters_test.ts
+++ b/src/test/type_parameters_test.ts
@@ -2,6 +2,7 @@
 import * as test  from "https://deno.land/std@0.208.0/assert/mod.ts";
 import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
 import * as infer from '../infer.ts';
+import { FunctionNdcKind } from "../schema.ts";
 
 Deno.test("Type Parameters", () => {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/type_parameters.ts'));
@@ -14,7 +15,7 @@ Deno.test("Type Parameters", () => {
   test.assertEquals(program_schema, {
     functions: {
       "bar": {
-        ndc_kind: infer.FunctionNdcKind.Procedure,
+        ndc_kind: FunctionNdcKind.Procedure,
         description: null,
         arguments: [],
         result_type: {

--- a/src/test/validation_algorithm_test.ts
+++ b/src/test/validation_algorithm_test.ts
@@ -2,6 +2,7 @@
 import * as test  from "https://deno.land/std@0.208.0/assert/mod.ts";
 import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
 import * as infer from '../infer.ts';
+import { FunctionNdcKind } from "../schema.ts";
 
 Deno.test("Validation Algorithm", () => {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/validation_algorithm_update.ts'));
@@ -12,7 +13,7 @@ Deno.test("Validation Algorithm", () => {
   test.assertEquals(program_results, {
     functions: {
       "bar": {
-        ndc_kind: infer.FunctionNdcKind.Procedure,
+        ndc_kind: FunctionNdcKind.Procedure,
         description: null,
         arguments: [
           {

--- a/src/test/validation_algorithm_test.ts
+++ b/src/test/validation_algorithm_test.ts
@@ -3,9 +3,7 @@ import * as test  from "https://deno.land/std@0.208.0/assert/mod.ts";
 import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
 import * as infer from '../infer.ts';
 
-Deno.test({ name: "Type Parameters",
- ignore: false,
- fn() {
+Deno.test("Validation Algorithm", () => {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/validation_algorithm_update.ts'));
   const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
 
@@ -280,4 +278,4 @@ Deno.test({ name: "Type Parameters",
       String: {},
     }
   });
-}});
+});

--- a/src/test/validation_algorithm_test.ts
+++ b/src/test/validation_algorithm_test.ts
@@ -1,7 +1,7 @@
 
-import * as test    from "https://deno.land/std@0.208.0/assert/mod.ts";
-import * as path    from "https://deno.land/std@0.208.0/path/mod.ts";
-import * as infer   from '../infer.ts';
+import * as test  from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
+import * as infer from '../infer.ts';
 
 Deno.test({ name: "Type Parameters",
  ignore: false,
@@ -9,237 +9,275 @@ Deno.test({ name: "Type Parameters",
   const program_path = path.fromFileUrl(import.meta.resolve('./data/validation_algorithm_update.ts'));
   const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
 
-  const program_results = infer.programInfo(program_path, vendor_path, false);
+  const program_results = infer.inferProgramSchema(program_path, vendor_path, false);
 
   test.assertEquals(program_results, {
-    positions: {
-      bar: [
-        "string",
-        "aliasedString",
-        "genericScalar",
-        "array",
-        "promise",
-        "anonObj",
-        "aliasedObj",
-        "genericAliasedObj",
-        "interfce",
-        "genericInterface",
-        "aliasedIntersectionObj",
-        "anonIntersectionObj",
-        "genericIntersectionObj",
-      ],
-    },
-    schema: {
-      collections: [],
-      functions: [],
-      object_types: {
-        "GenericBar<string>": {
-          fields: {
-            data: {
-              type: {
-                name: "String",
-                type: "named",
-              },
-            },
+    functions: {
+      "bar": {
+        ndc_kind: infer.FunctionNdcKind.Procedure,
+        description: null,
+        arguments: [
+          {
+            argument_name: "string",
+            description: null,
+            type: {
+              type: "named",
+              kind: "scalar",
+              name: "String"
+            }
           },
-        },
-        "GenericIntersectionObject<string>": {
-          fields: {
-            data: {
-              type: {
-                name: "String",
-                type: "named",
-              },
-            },
-            test: {
-              type: {
-                name: "String",
-                type: "named",
-              },
-            },
+          {
+            argument_name: "aliasedString",
+            description: null,
+            type: {
+              type: "named",
+              kind: "scalar",
+              name: "String"
+            }
           },
-        },
-        Bar: {
-          fields: {
-            test: {
-              type: {
-                name: "String",
-                type: "named",
-              },
-            },
+          {
+            argument_name: "genericScalar",
+            description: null,
+            type: {
+              type: "named",
+              kind: "scalar",
+              name: "String"
+            }
           },
-        },
-        IGenericThing: {
-          fields: {
-            data: {
-              type: {
-                name: "String",
+          {
+            argument_name: "array",
+            description: null,
+            type: {
+              type: "array",
+              element_type: {
                 type: "named",
-              },
-            },
+                kind: "scalar",
+                name: "String"
+              }
+            }
           },
-        },
-        IThing: {
-          fields: {
-            prop: {
-              type: {
-                name: "String",
-                type: "named",
-              },
-            },
+          {
+            argument_name: "promise",
+            description: null,
+            type: {
+              type: "named",
+              kind: "scalar",
+              name: "String"
+            }
           },
-        },
-        IntersectionObject: {
-          fields: {
-            test: {
-              type: {
-                name: "String",
-                type: "named",
-              },
-            },
-            wow: {
-              type: {
-                name: "String",
-                type: "named",
-              },
-            },
+          {
+            argument_name: "anonObj",
+            description: null,
+            type: {
+              type: "named",
+              kind: "object",
+              name: "bar_arguments_anonObj"
+            }
           },
-        },
-        bar_arguments_anonIntersectionObj: {
-          fields: {
-            num: {
-              type: {
-                name: "Float",
-                type: "named",
-              },
-            },
-            test: {
-              type: {
-                name: "String",
-                type: "named",
-              },
-            },
+          {
+            argument_name: "aliasedObj",
+            description: null,
+            type: {
+              type: "named",
+              kind: "object",
+              name: "Bar"
+            }
           },
-        },
-        bar_arguments_anonObj: {
-          fields: {
-            a: {
-              type: {
-                name: "Float",
-                type: "named",
-              },
-            },
-            b: {
-              type: {
-                name: "String",
-                type: "named",
-              },
-            },
+          {
+            argument_name: "genericAliasedObj",
+            description: null,
+            type: {
+              type: "named",
+              kind: "object",
+              name: "GenericBar<string>"
+            }
           },
-        },
-      },
-      procedures: [
-        {
-          arguments: {
-            aliasedIntersectionObj: {
-              type: {
-                name: "IntersectionObject",
-                type: "named",
-              },
-            },
-            aliasedObj: {
-              type: {
-                name: "Bar",
-                type: "named",
-              },
-            },
-            aliasedString: {
-              type: {
-                name: "String",
-                type: "named",
-              },
-            },
-            anonIntersectionObj: {
-              type: {
-                name: "bar_arguments_anonIntersectionObj",
-                type: "named",
-              },
-            },
-            anonObj: {
-              type: {
-                name: "bar_arguments_anonObj",
-                type: "named",
-              },
-            },
-            array: {
-              type: {
-                element_type: {
-                  name: "String",
-                  type: "named",
-                },
-                type: "array",
-              },
-            },
-            genericAliasedObj: {
-              type: {
-                name: "GenericBar<string>",
-                type: "named",
-              },
-            },
-            genericInterface: {
-              type: {
-                name: "IGenericThing",
-                type: "named",
-              },
-            },
-            genericIntersectionObj: {
-              type: {
-                name: "GenericIntersectionObject<string>",
-                type: "named",
-              },
-            },
-            genericScalar: {
-              type: {
-                name: "String",
-                type: "named",
-              },
-            },
-            interfce: {
-              type: {
-                name: "IThing",
-                type: "named",
-              },
-            },
-            promise: {
-              type: {
-                name: "String",
-                type: "named",
-              },
-            },
-            string: {
-              type: {
-                name: "String",
-                type: "named",
-              },
-            },
+          {
+            argument_name: "interfce",
+            description: null,
+            type: {
+              type: "named",
+              kind: "object",
+              name: "IThing"
+            }
           },
-          name: "bar",
-          result_type: {
-            name: "String",
-            type: "named",
+          {
+            argument_name: "genericInterface",
+            description: null,
+            type: {
+              type: "named",
+              kind: "object",
+              name: "IGenericThing"
+            }
           },
-        },
-      ],
-      scalar_types: {
-        Float: {
-          aggregate_functions: {},
-          comparison_operators: {},
-        },
-        String: {
-          aggregate_functions: {},
-          comparison_operators: {},
-        },
+          {
+            argument_name: "aliasedIntersectionObj",
+            description: null,
+            type: {
+              type: "named",
+              kind: "object",
+              name: "IntersectionObject"
+            }
+          },
+          {
+            argument_name: "anonIntersectionObj",
+            description: null,
+            type: {
+              type: "named",
+              kind: "object",
+              name: "bar_arguments_anonIntersectionObj"
+            }
+          },
+          {
+            argument_name: "genericIntersectionObj",
+            description: null,
+            type: {
+              type: "named",
+              kind: "object",
+              name: "GenericIntersectionObject<string>"
+            }
+          },
+        ],
+        result_type: {
+          name: "String",
+          kind: "scalar",
+          type: "named",
+        }
       }
+    },
+    object_types: {
+      "GenericBar<string>": {
+        properties: [
+          {
+            property_name: "data",
+            type: {
+              name: "String",
+              kind: "scalar",
+              type: "named",
+            },
+          },
+        ],
+      },
+      "GenericIntersectionObject<string>": {
+        properties: [
+          {
+            property_name: "data",
+            type: {
+              name: "String",
+              kind: "scalar",
+              type: "named",
+            },
+          },
+          {
+            property_name: "test",
+            type: {
+              name: "String",
+              kind: "scalar",
+              type: "named",
+            },
+          },
+        ],
+      },
+      Bar: {
+        properties: [
+          {
+            property_name: "test",
+            type: {
+              name: "String",
+              kind: "scalar",
+              type: "named",
+            },
+          },
+        ],
+      },
+      IGenericThing: {
+        properties: [
+          {
+            property_name: "data",
+            type: {
+              name: "String",
+              kind: "scalar",
+              type: "named",
+            },
+          },
+        ],
+      },
+      IThing: {
+        properties: [
+          {
+            property_name: "prop",
+            type: {
+              name: "String",
+              kind: "scalar",
+              type: "named",
+            },
+          },
+        ],
+      },
+      IntersectionObject: {
+        properties: [
+          {
+            property_name: "wow",
+            type: {
+              name: "String",
+              kind: "scalar",
+              type: "named",
+            },
+          },
+          {
+            property_name: "test",
+            type: {
+              name: "String",
+              kind: "scalar",
+              type: "named",
+            },
+          },
+        ],
+      },
+      bar_arguments_anonIntersectionObj: {
+        properties: [
+          {
+            property_name: "num",
+            type: {
+              name: "Float",
+              kind: "scalar",
+              type: "named",
+            },
+          },
+          {
+            property_name: "test",
+            type: {
+              name: "String",
+              kind: "scalar",
+              type: "named",
+            },
+          },
+        ],
+      },
+      bar_arguments_anonObj: {
+        properties: [
+          {
+            property_name: "a",
+            type: {
+              name: "Float",
+              kind: "scalar",
+              type: "named",
+            },
+          },
+          {
+            property_name: "b",
+            type: {
+              name: "String",
+              kind: "scalar",
+              type: "named",
+            },
+          },
+        ],
+      },
+    },
+    scalar_types: {
+      Float: {},
+      String: {},
     }
   });
 }});

--- a/src/test/void_test.ts
+++ b/src/test/void_test.ts
@@ -6,7 +6,7 @@ import * as infer from '../infer.ts';
 // NOTE: It would be good to have explicit timeout for this
 // See: https://github.com/denoland/deno/issues/11133
 // Test bug: https://github.com/hasura/ndc-typescript-deno/issues/45
-Deno.test("Inferred Dependency Based Result Type", () => {
+Deno.test("Void", () => {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/void_types.ts'));
   const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
   test.assertThrows(() => {

--- a/src/test/void_test.ts
+++ b/src/test/void_test.ts
@@ -1,7 +1,7 @@
 
-import * as test    from "https://deno.land/std@0.208.0/assert/mod.ts";
-import * as path    from "https://deno.land/std@0.208.0/path/mod.ts";
-import * as infer   from '../infer.ts';
+import * as test  from "https://deno.land/std@0.208.0/assert/mod.ts";
+import * as path  from "https://deno.land/std@0.208.0/path/mod.ts";
+import * as infer from '../infer.ts';
 
 // NOTE: It would be good to have explicit timeout for this
 // See: https://github.com/denoland/deno/issues/11133
@@ -10,6 +10,6 @@ Deno.test("Inferred Dependency Based Result Type", () => {
   const program_path = path.fromFileUrl(import.meta.resolve('./data/void_types.ts'));
   const vendor_path = path.fromFileUrl(import.meta.resolve('./vendor'));
   test.assertThrows(() => {
-    infer.programInfo(program_path, vendor_path, false);
+    infer.inferProgramSchema(program_path, vendor_path, false);
   })
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,13 @@
+export const unreachable = (x: never): never => { throw new Error(`Unreachable code reached! The types lied! 😭 Unexpected value: ${x}`) };
+
+export function isArray(x: unknown): x is unknown[] {
+  return Array.isArray(x);
+}
+
+export function mapObjectValues<T, U>(obj: { [k: string]: T }, fn: (value: T, propertyName: string) => U): Record<string, U> {
+  return Object.fromEntries(Object.entries(obj).map(([prop, val]) => [prop, fn(val, prop)]));
+}
+
+export function mapObject<I, O>(obj: {[key: string]: I}, fn: ((key: string, value: I) => [string, O])): {[key: string]: O} {
+  return Object.fromEntries(Object.entries(obj).map(([prop, val]) => fn(prop,val)));
+}


### PR DESCRIPTION
This PR adds support for using "nullable" TypeScript types such as `String | null`, `String | undefined`, `String | null | undefined`, and optional object properties. These are expressed as nullable NDC types in the schema.
When null or omitted arguments/object properties are received in query, any null/omissions are coerced into what the type actually accepts. So:
* `string | null` -> coerce omissions to null, and explicit nulls are passed through.
* `string | undefined`  -> omission is passed as undefined, and explicit nulls are coerced to undefined.
* `string | null | undefined` you don't perform any coercions, omission is passed as undefined and explicit null is passed through

Some large refactoring has taken place to support this nicely. The inference process now produces a `ProgramSchema` which replaces `ProgramInfo`. This contains the entire inferred schema in an internal format that retains additional information required to perform the above type coercions, and also innately captures function argument ordering (previously captured in `FunctionPositions`). The NDC schema is then extracted from that internal schema when you hit the `/schema` endpoint.

When returning a response, we also coerce all undefineds into nulls, because when we requests a field, if the "column" is undefined, we still must return the field, so the value must be null. This only works at the top level and is not applied recursively into deep object structures, because we don't yet have nested field query support in NDC.

The inference tests now compare against the internal schema format, not the NDC schema. There is a new `ndc_schema_test.ts` file that tests the conversion from the internal schema to the NDC schema.
There are also new tests to test the argument coercion logic in `prepare_arguments_tests.ts`.

Fixes: https://github.com/hasura/ndc-typescript-deno/issues/36