### PR TITLE
Support Variables for default N+1 relationship queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This changelog documents the changes between release versions.
 
 Changes to be included in the next upcoming release.
 
-* Support for query variables - "ForEach"
+* Support for query variables AKA "ForEach"
 
 ## v0.21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This changelog documents the changes between release versions.
 
 Changes to be included in the next upcoming release.
 
+* Support for query variables - "ForEach"
+
 ## v0.21
 
 Support for "nullable" types, for example `string | null`, `string | undefined`, `string | null | undefined`,

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -78,6 +78,7 @@ export const CAPABILITIES_RESPONSE: sdk.CapabilitiesResponse = {
   versions: "^0.1.0",
   capabilities: {
     query: {
+      variables: {}
     },
   },
 };

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -146,9 +146,10 @@ async function invoke(function_name: string, args: Record<string, unknown>, func
   const prepared_args = prepare_arguments(function_name, args, program_schema.functions, program_schema.object_types);
 
   try {
-    let result = func.apply(undefined, prepared_args);
+    const result = func.apply(undefined, prepared_args);
+    // Resolve the result if it is a promise
     if (typeof result === "object" && 'then' in result && typeof result.then === "function") {
-      result = await result;
+      return await result;
     }
     return result;
   } catch (e) {
@@ -249,7 +250,7 @@ async function query(
   state: State,
   functionName: string,
   requestArgs: Struct<unknown>,
-  requestFields?: { [k: string]: sdk.Field; } | null | undefined
+  requestFields: { [k: string]: sdk.Field; } | null,
 ): Promise<unknown> {
   const result = await invoke(functionName, requestArgs, state.functions, configuration.programSchema);
   return pruneFields(functionName, requestFields, result);
@@ -258,13 +259,22 @@ async function query(
 function resolveArguments(
   func: string,
   requestArgs: Struct<sdk.Argument>,
+  requestVariables: { [k: string]: unknown },
 ): Struct<unknown> {
   const args = Object.fromEntries(Object.entries(requestArgs).map(([k,v], _i) => {
-    switch(v.type) {
+    const t = v.type;
+    switch(t) {
       case 'literal':
         return [k, v.value];
+      case 'variable': {
+        if(!(v.name in requestVariables)) {
+          throw new Error(`Variable ${v.name} not found for function ${func}`);
+        }
+        const value = requestVariables[v.name];
+        return [k, value];
+      }
       default:
-        throw new Error(`Function ${func} argument ${k} of type ${v.type} not supported.`);
+        return unreachable(t)
     }
   }));
   return args;
@@ -347,13 +357,17 @@ export const connector: sdk.Connector<RawConfiguration, Configuration, State> = 
     state: State,
     request: sdk.QueryRequest
   ): Promise<sdk.QueryResponse> {
-    const args = resolveArguments(request.collection, request.arguments);
-    const result = await query(configuration, state, request.collection, args, request.query.fields);
+
+    const rows = [];
+    for(const variables of request.variables ?? [{}]) {
+      const args = resolveArguments(request.collection, request.arguments, variables);
+      const result = await query(configuration, state, request.collection, args, request.query.fields ?? null);
+      rows.push({ '__value': result });
+    }
+
     return [{
       aggregates: {},
-      rows: [{
-        '__value': result
-      }]
+      rows
     }];
   },
 
@@ -366,7 +380,7 @@ export const connector: sdk.Connector<RawConfiguration, Configuration, State> = 
     for(const op of request.operations) {
       switch(op.type) {
         case 'procedure': {
-          const result = await query(configuration, state, op.name, op.arguments, op.fields);
+          const result = await query(configuration, state, op.name, op.arguments, op.fields ?? null);
           results.push({
             affected_rows: 1,
             returning: [{


### PR DESCRIPTION
Partially addresses: https://github.com/hasura/ndc-typescript-deno/issues/24

Does not implement batching.

Returns multiple results in the format:

```javascript
[
  { '__value': result1 },
  { '__value': result2 }
]
```

## Examples

Single variable set:

<img height="200" alt="image" src="https://github.com/hasura/ndc-typescript-deno/assets/92299/fd7c9a03-c0b0-430b-9f2f-dfbeda41f647">

Multiple variable sets:

<img height="200" alt="image" src="https://github.com/hasura/ndc-typescript-deno/assets/92299/ea8932c4-3222-48bf-8f50-082933cbb812">

Missing variable:

<img  height="200" alt="image" src="https://github.com/hasura/ndc-typescript-deno/assets/92299/1947b2c0-413a-46d7-a883-874e971cdd86">

Normal request:

<img  height="200" alt="image" src="https://github.com/hasura/ndc-typescript-deno/assets/92299/5d4a8e75-b811-4935-a6ab-7d208d171cba">

