### PR TITLE
Update ndc-sdk-typescript to v1.2.6 to address SERVICE_TOKEN issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This changelog documents the changes between release versions.
 
 Changes to be included in the next upcoming release.
 
+## v0.22
+
+Update TS SDK Dependency to v1.2.6.
+
+* Fixes issue with SERVICE_TOKEN check
+
 ## v0.21
 
 Support for "nullable" types, for example `string | null`, `string | undefined`, `string | null | undefined`,

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -9,8 +9,7 @@ import { resolve } from "https://deno.land/std@0.208.0/path/mod.ts";
 import { JSONSchemaObject } from "npm:@json-schema-tools/meta-schema";
 import { isArray, unreachable } from "./util.ts";
 
-import * as sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.5';
-export * as sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.5';
+import { sdk } from './sdk.ts';
 
 export type State = {
   functions: RuntimeFunctions

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -6,7 +6,7 @@
 import * as commander  from 'npm:commander@11.0.0';
 import { inferProgramSchema } from './infer.ts'
 import { connector } from './connector.ts'
-import sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.5';
+import { sdk } from './sdk.ts';
 
 const inferCommand = new commander.Command("infer")
   .argument('<path>', 'TypeScript source entrypoint')

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,4 +1,4 @@
-import * as sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.5';
+import { sdk } from './sdk.ts';
 import { mapObjectValues, unreachable } from "./util.ts";
 
 export type ProgramSchema = {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,0 +1,4 @@
+
+// Have this dependency defined in one place
+
+export * as sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.6';


### PR DESCRIPTION
# Update ndc-sdk-typescript to v1.2.6 to address SERVICE_TOKEN_SECRET issue

SERVICE_TOKEN_SECRET wasn't being checked correctly in the SDK.

See PR: https://github.com/hasura/ndc-sdk-typescript/pull/11

## Changelog

### Type

- [x] bugfix

### Changelog entry

- See CHANGELOG.md

> ## v0.22
>
> Update TS SDK Dependency to v1.2.6.
> 
> * Fixes issue with SERVICE_TOKEN check
