### PR TITLE
Fixed queries with variables returning incorrect result format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This changelog documents the changes between release versions.
 
 Changes to be included in the next upcoming release.
 
+Update TS SDK dependency to v1.2.8.
+
+* Fixed issue where query response format was incorrect when variables were used in the request
+
 ## v0.22
 
 Update TS SDK Dependency to v1.2.6.

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -357,17 +357,19 @@ export const connector: sdk.Connector<RawConfiguration, Configuration, State> = 
     request: sdk.QueryRequest
   ): Promise<sdk.QueryResponse> {
 
-    const rows = [];
+    const rowSets: sdk.RowSet[] = [];
     for(const variables of request.variables ?? [{}]) {
       const args = resolveArguments(request.collection, request.arguments, variables);
       const result = await query(configuration, state, request.collection, args, request.query.fields ?? null);
-      rows.push({ '__value': result });
+      rowSets.push({
+        aggregates: {},
+        rows: [
+          { '__value': result }
+        ]
+      });
     }
 
-    return [{
-      aggregates: {},
-      rows
-    }];
+    return rowSets;
   },
 
   async mutation(

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,4 +1,4 @@
 
 // Have this dependency defined in one place
 
-export * as sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.6';
+export * as sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.8';


### PR DESCRIPTION
Fixed response format being incorrect (multiple rows instead of multiple row sets!) when variables were used in the query request.

## Changelog
### Type
_(Select only one. In case of multiple, choose the most appropriate)_
- [ ] highlight
- [ ] enhancement
- [x] bugfix
- [ ] behaviour-change
- [ ] performance-enhancement
- [ ] security-fix
<!-- type : end : DO NOT REMOVE -->

### Changelog entry
<!--
  - Add a user understandable changelog entry
  - Include all details needed to understand the change. Try including links to docs or issues if relevant
  - For Highlights start with a H4 heading (#### <entry title>)
  - Get the changelog entry reviewed by your team
-->

Fixed queries with variables returning incorrect result format

<!-- changelog-entry : end : DO NOT REMOVE -->

<!-- changelog : end : DO NOT REMOVE -->
