### PR TITLE
Pin Fastify dependency version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This changelog documents the changes between release versions.
 
 Changes to be included in the next upcoming release.
 
+## v0.24
+
+* Pinned the Fastify version used to avoid using the latest version which does not work with Deno
+
 ## v0.23
 
 Update TS SDK dependency to v1.2.8.

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,4 +1,5 @@
-
+// This pins the fastify version (transitively used by the ndc-sdk-typescript)
+// because 4.26.0 introduces a deno-incompatible change
+import fastify from "npm:fastify@4.25.2"
 // Have this dependency defined in one place
-
 export * as sdk from 'npm:@hasura/ndc-sdk-typescript@1.2.8';


### PR DESCRIPTION
This PR pins the version of Fastify used to ensure that we avoid using the latest version which is not compatible with Deno because it uses AsyncResource.emitDestroy.

Fastify incompatible changes:
![image](https://github.com/hasura/ndc-typescript-deno/assets/1214352/6bc2776d-6322-4523-97e0-d7d58e65c19d)

## Changelog

- Add a changelog entry (in the "Changelog entry" section below) if the changes in this PR have any user-facing impact.
- If no changelog is required ignore/remove this section and add a `no-changelog-required` label to the PR.

### Type
_(Select only one. In case of multiple, choose the most appropriate)_
- [ ] highlight
- [ ] enhancement
- [x] bugfix
- [ ] behaviour-change
- [ ] performance-enhancement
- [ ] security-fix
<!-- type : end : DO NOT REMOVE -->

### Changelog entry
<!--
  - Add a user understandable changelog entry
  - Include all details needed to understand the change. Try including links to docs or issues if relevant
  - For Highlights start with a H4 heading (#### <entry title>)
  - Get the changelog entry reviewed by your team
-->

Pinned the Fastify version used to avoid using the latest version which does not work with Deno

<!-- changelog-entry : end : DO NOT REMOVE -->

<!-- changelog : end : DO NOT REMOVE -->
