### PR TITLE
Remove hyphen from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ export function make_bad_password_hash(pw: string): string {
 /**
  * Returns the github bio for the userid provided
  *
- * @param username - Username of the user who's bio will be fetched.
+ * @param username Username of the user who's bio will be fetched.
  * @returns The github bio for the requested user.
  * @pure This function should only query data without making modifications
  */

--- a/src/README.md
+++ b/src/README.md
@@ -44,7 +44,7 @@ export function make_bad_password_hash(pw: string): string {
 /**
  * Returns the github bio for the userid provided
  *
- * @param username - Username of the user who's bio will be fetched.
+ * @param username Username of the user who's bio will be fetched.
  * @returns The github bio for the requested user.
  * @pure This function should only query data without making modifications
  */


### PR DESCRIPTION
Removing a hyphen from the code example, which triggers a bug in the LSP (it doesn't escape it in YAML).
